### PR TITLE
Add Azure Pipelines CI and some of our usual Maven checks

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -1,0 +1,18 @@
+# Triggers
+trigger:
+  branches:
+    include:
+      - 'main'
+      - 'release-*'
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'
+
+# Stages
+stages:
+  - stage: java_build
+    displayName: Java build
+    jobs:
+      - template: 'templates/jobs/build_java.yaml'

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -1,0 +1,52 @@
+jobs:
+  - job: 'build_and_test_java'
+    displayName: 'Build & Test'
+    # Strategy for the job
+    strategy:
+      matrix:
+        'java-11':
+          image: 'Ubuntu-20.04'
+          jdk_version: '11'
+          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+          main_build: 'true'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: $(image)
+    # Variables
+    variables:
+      MVN_CACHE_FOLDER: $(HOME)/.m2/repository
+      MVN_ARGS: '-e -V -B'
+    # Pipeline steps
+    steps:
+      # Get cached Maven repository
+      - template: "../steps/maven_cache.yaml"
+      - template: '../steps/setup_java.yaml'
+        parameters:
+          JDK_PATH: $(jdk_path)
+          JDK_VERSION: $(jdk_version)
+      - bash: "make spotbugs"
+        displayName: "Spotbugs"
+        env:
+          MVN_ARGS: "-e -V -B"
+      - bash: "make java_verify"
+        displayName: "Build & Test Java"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          MVN_ARGS: "-e -V -B"
+      # We have to TAR the target directory to maintain the permissions of
+      # the files which would otherwise change when downloading the artifact
+      - bash: tar -cvpf target.tar ./target
+        displayName: "Tar the target directory"
+        condition: and(succeeded(), eq(variables['main_build'], 'true'))
+      - publish: $(System.DefaultWorkingDirectory)/target.tar
+        artifact: Binary
+        condition: and(succeeded(), eq(variables['main_build'], 'true'))
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: '**/TEST-*.xml'
+          testRunTitle: "Unit & Integration tests"
+        condition: always()

--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      restoreKeys: |
+        maven-cache | $(System.JobName)
+        maven-cache
+      path: $(HOME)/.m2/repository
+    displayName: Maven cache

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,0 +1,35 @@
+# Step to setup JAVA on the agent
+# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 11
+parameters:
+  - name: JDK_PATH
+    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+  - name: JDK_VERSION
+    default: '1.8'
+
+steps:
+  - bash: |
+      sudo apt-get update
+    displayName: 'Update package list'
+  - bash: |
+      sudo apt-get install openjdk-8-jdk
+    displayName: 'Install openjdk8'
+    condition: eq(variables['JDK_VERSION'], '1.8')
+  - bash: |
+      sudo apt-get install openjdk-11-jdk
+    displayName: 'Install openjdk11'
+    condition: eq(variables['JDK_VERSION'], '11')
+  - bash: |
+      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
+      echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
+    displayName: 'Setup JAVA_VERSION=1.8'
+    condition: eq(variables['JDK_VERSION'], '1.8')
+  - bash: |
+      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
+      echo "##vso[task.setvariable variable=JAVA_VERSION]11"
+    displayName: 'Setup JAVA_VERSION=11'
+    condition: eq(variables['JDK_VERSION'], '11')
+  - bash: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
+      echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"
+      echo "##vso[task.setvariable variable=PATH]$(jdk_path)/bin:$(PATH)"
+    displayName: 'Setup JAVA_HOME'

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,28 +1,18 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 11
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+    default: '/usr/lib/jvm/java-11-openjdk-amd64'
   - name: JDK_VERSION
-    default: '1.8'
+    default: '11'
 
 steps:
   - bash: |
       sudo apt-get update
     displayName: 'Update package list'
   - bash: |
-      sudo apt-get install openjdk-8-jdk
-    displayName: 'Install openjdk8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
-  - bash: |
       sudo apt-get install openjdk-11-jdk
     displayName: 'Install openjdk11'
     condition: eq(variables['JDK_VERSION'], '11')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
-    displayName: 'Setup JAVA_VERSION=1.8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
   - bash: |
       echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
       echo "##vso[task.setvariable variable=JAVA_VERSION]11"

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -5,11 +5,11 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
-    <!-- cluster-operator -->
-<!--    <suppress checks="<check name>"-->
-<!--              files="package[/\\]name[/\\]MyClass.java"/>-->
-
+    <!-- Use this file to suppress warnings only when absolutely needed:
+               * To suppress a bunch of class (for example generated code)
+               * To suppress warning we do not want for the whole project
+               * To suppress file-level warnings
+         In all other cases, you should use the annotations on the methods or classes affected by it. -->
 </suppressions>

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,73 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main, release* ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '23 17 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    # Setup OpenJDK 11
+    - name: Setup java
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: 11
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <!-- This allows us to use singleton pattern -->
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+</FindBugsFilter>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+include ./Makefile.os
+include ./Makefile.maven
+
+PROJECT_NAME ?= access-operator
+GITHUB_VERSION ?= main
+RELEASE_VERSION ?= latest
+
+ifneq ($(RELEASE_VERSION),latest)
+  GITHUB_VERSION = $(RELEASE_VERSION)
+endif
+
+.PHONY: all
+all: java_verify
+
+.PHONY: clean
+clean: java_clean
+
+.PHONY: next_version
+next_version:
+	echo $(shell echo $(NEXT_VERSION) | tr a-z A-Z) > release.version
+	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)
+	mvn versions:commit

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -1,0 +1,31 @@
+# Makefile.maven contains the shared tasks for building Java applications. This file is
+# included into the Makefile files which contain some Java sources which should be build
+
+.PHONY: java_compile
+java_compile:
+	echo "Building JAR file ..."
+	mvn $(MVN_ARGS) compile
+
+.PHONY: java_verify
+java_verify:
+	echo "Building JAR file ..."
+	mvn $(MVN_ARGS) verify
+
+.PHONY: java_package
+java_package:
+	echo "Packaging project ..."
+	mvn $(MVN_ARGS) package
+
+.PHONY: java_install
+java_install:
+	echo "Installing JAR files ..."
+	mvn $(MVN_ARGS) install
+
+.PHONY: java_clean
+java_clean:
+	echo "Cleaning Maven build ..."
+	mvn clean
+
+.PHONY: spotbugs
+spotbugs: java_compile
+	mvn $(MVN_ARGS) spotbugs:check

--- a/Makefile.os
+++ b/Makefile.os
@@ -1,0 +1,12 @@
+FIND = find
+SED = sed
+GREP = grep
+CP = cp
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	FIND = gfind
+	SED = gsed
+	GREP = ggrep
+	CP = gcp
+endif

--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,14 @@
         </developer>
         <developer>
             <name>Stanislav Knot</name>
-            <email>sknot@redhat.com</email>
-            <organization>Red Hat</organization>
-            <organizationUrl>https://www.redhat.com</organizationUrl>
+            <email>knot@cngroup.dk</email>
+            <organization>CN Group</organization>
+            <organizationUrl>https://www.cngroup.dk</organizationUrl>
         </developer>
     </developers>
 
     <properties>
+        <!-- Build dependencies -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -79,17 +80,24 @@
         <checkstyle.version>9.0.1</checkstyle.version>
         <maven.surefire.version>3.0.0-M5</maven.surefire.version>
         <maven.license.version>2.11</maven.license.version>
-        <spotbugs.version>4.0.3</spotbugs.version>
+        <spotbugs.version>4.5.3</spotbugs.version>
+        <spotbugs-maven-plugin.version>4.5.3.0</spotbugs-maven-plugin.version>
         <maven.javadoc.version>3.1.0</maven.javadoc.version>
         <maven.shade.version>3.1.0</maven.shade.version>
+        <maven.dependency.version>3.3.0</maven.dependency.version>
+        <maven.assembly.version>3.3.0</maven.assembly.version>
+
+        <!-- Runtime dependencies -->
         <javaoperatorsdk.version>2.0.1</javaoperatorsdk.version>
         <fabric8.version>5.11.2</fabric8.version>
         <strimzi.version>0.27.0</strimzi.version>
         <kafka.clients.version>3.0.0</kafka.clients.version>
-        <javax.version>2.0.1.Final</javax.version>
-        <junit.version>5.8.2</junit.version>
+        <javax-validation.version>2.0.1.Final</javax-validation.version>
+        <slf4j.version>1.7.33</slf4j.version>
+
+        <!-- Test dependencies -->
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <assertj.version>3.21.0</assertj.version>
-        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <distributionManagement>
@@ -103,18 +111,6 @@
         </repository>
     </distributionManagement>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.javaoperatorsdk</groupId>
@@ -122,10 +118,24 @@
             <version>${javaoperatorsdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>operator-framework-core</artifactId>
+            <version>${javaoperatorsdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>crd-generator-apt</artifactId>
+            <artifactId>kubernetes-client</artifactId>
             <version>${fabric8.version}</version>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+            <version>${fabric8.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-common</artifactId>
+            <version>${fabric8.version}</version>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -146,16 +156,24 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>${javax.version}</version>
+            <version>${javax-validation.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -212,23 +230,9 @@
                 <version>${maven.surefire.version}</version>
             </plugin>
             <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>${maven.license.version}</version>
-                <configuration>
-                    <aggregate>true</aggregate>
-                    <header>header.txt</header>
-                    <properties>
-                        <owner>Red Hat, Inc.</owner>
-                    </properties>
-                    <excludes>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <version>${spotbugs-maven-plugin.version}</version>
                 <dependencies>
                     <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
                     <dependency>
@@ -244,9 +248,9 @@
                     <!-- Produces XML report -->
                     <xmlOutput>true</xmlOutput>
                     <!-- Configures the directory in which the XML report is created -->
-                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs</spotbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs/</spotbugsXmlOutputDirectory>
                     <!-- Configures the file for excluding warnings -->
-                    <excludeFilterFile>${project.basedir}/../.spotbugs/spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.basedir}/.spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -270,22 +274,35 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven.shade.version}</version>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.version}</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>single</goal>
                         </goals>
                         <configuration>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>io.strimzi.kafka.access.KafkaAccessOperator</mainClass>
-                                </transformer>
-                            </transformers>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/zip.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -1,0 +1,29 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <outputDirectory>/libs</outputDirectory>
+            <fileMode>0644</fileMode>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/io/strimzi/kafka/access/model/KafkaAccess.java
+++ b/src/main/java/io/strimzi/kafka/access/model/KafkaAccess.java
@@ -14,7 +14,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Version("v1")
 @ShortNames("ka")
 public class KafkaAccess extends CustomResource<KafkaAccessSpec, KafkaAccessStatus> implements Namespaced {
-
+    private static final long serialVersionUID = 1L;
     public static final String KIND = "KafkaAccess";
 
     @Override


### PR DESCRIPTION
This PR adds the basic Azure Pipelines CI and some of our usual Maven checks to the project. The Azure Pipelines CI currently only builds the Java code since there are no docker images or anything like that. It runs unit and integration tests and spotbugs.

In addition to the CI, this PR also changes the packaging to use more easy to use archive with separate libs and and dependency check to track used / unused dependencies.