### PR TITLE
feat: Refactor tests to not call reconcile directly

### DIFF
--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -90,7 +90,7 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
         }
     }
 
-    private Map<String, String> secretData(final KafkaAccessSpec spec, final String kafkaAccessNamespace) {
+    protected Map<String, String> secretData(final KafkaAccessSpec spec, final String kafkaAccessNamespace) {
         final KafkaReference kafkaReference = spec.getKafka();
         final String kafkaClusterNamespace = Optional.ofNullable(kafkaReference.getNamespace()).orElse(kafkaAccessNamespace);
         final Optional<KafkaUserReference> kafkaUserReference = Optional.ofNullable(spec.getUser());

--- a/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
+++ b/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
@@ -112,6 +112,14 @@ public class ResourceProvider {
         return kafkaReference;
     }
 
+    public static KafkaReference getKafkaReferenceWithListener(final String kafkaName, final String listenerName, final String kafkaNamespace) {
+        final KafkaReference kafkaReference = new KafkaReference();
+        kafkaReference.setName(kafkaName);
+        kafkaReference.setListener(listenerName);
+        Optional.ofNullable(kafkaNamespace).ifPresent(kafkaReference::setNamespace);
+        return kafkaReference;
+    }
+
     public static KafkaUserReference getKafkaUserReference(final String kafkaUserName, final String kafkaUserNamespace) {
         final KafkaUserReference kafkaUserReference = new KafkaUserReference();
         kafkaUserReference.setKind(KafkaUser.RESOURCE_KIND);

--- a/src/test/java/io/strimzi/kafka/access/SecretDataTest.java
+++ b/src/test/java/io/strimzi/kafka/access/SecretDataTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.access;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
+import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.kafka.access.model.KafkaAccess;
+import io.strimzi.kafka.access.model.KafkaReference;
+import io.strimzi.kafka.access.model.KafkaUserReference;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnableKubernetesMockClient(crud = true)
+public class SecretDataTest {
+
+    private static final String NAME = "kafka-access-name";
+    private static final String NAMESPACE = "kafka-access-namespace";
+    private static final String LISTENER_1 = "listener-1";
+    private static final String LISTENER_2 = "listener-2";
+    private static final String BOOTSTRAP_HOST = "my-kafka-name.svc";
+    private static final String KAFKA_NAME = "my-kafka-name";
+    private static final String KAFKA_NAMESPACE = "kafka-namespace";
+    private static final int BOOTSTRAP_PORT_9092 = 9092;
+    private static final int BOOTSTRAP_PORT_9093 = 9093;
+
+    KubernetesClient client;
+
+    @Test
+    @DisplayName("When secretData is called with a KafkaAccess resource, then the data returned includes the " +
+            "default information and the bootstrapServer")
+    void testSecretData() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false)),
+                List.of(ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092))
+        );
+        Crds.kafkaOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafka).create();
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
+
+        Map<String, String> data = new KafkaAccessReconciler(client).secretData(kafkaAccess.getSpec(), NAMESPACE);
+        final Base64.Encoder encoder = Base64.getEncoder();
+        final Map<String, String> expectedDataEntries = new HashMap<>();
+        expectedDataEntries.put("type", encoder.encodeToString("kafka".getBytes(StandardCharsets.UTF_8)));
+        expectedDataEntries.put("provider", encoder.encodeToString("strimzi".getBytes(StandardCharsets.UTF_8)));
+        expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092).getBytes(StandardCharsets.UTF_8)));
+        assertThat(data).containsAllEntriesOf(expectedDataEntries);
+    }
+
+    @Test
+    @DisplayName("When secretData is called with a KafkaAccess resource that references a KafkaUser, then the data returned includes the " +
+            "bootstrapServer for the listener")
+    void testSecretDataWithKafkaUser() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())),
+                List.of(ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
+        );
+        Crds.kafkaOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafka).create();
+
+        final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithoutStatus(KAFKA_NAME, KAFKA_NAMESPACE, new KafkaUserScramSha512ClientAuthentication());
+        Crds.kafkaUserOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafkaUser).create();
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReferenceWithListener(KAFKA_NAME, LISTENER_2, KAFKA_NAMESPACE);
+        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
+
+        Map<String, String> data = new KafkaAccessReconciler(client).secretData(kafkaAccess.getSpec(), NAMESPACE);
+        final Base64.Encoder encoder = Base64.getEncoder();
+        assertThat(data).containsEntry(
+                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093).getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @Test
+    @DisplayName("When secretData is called with a KafkaAccess resource and the referenced Kafka resource is missing, " +
+            "then it throws an exception")
+    void testSecretDataMissingKafka() {
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
+
+        assertThrows(IllegalStateException.class, () -> new KafkaAccessReconciler(client).secretData(kafkaAccess.getSpec(), NAMESPACE));
+    }
+
+    @Test
+    @DisplayName("When secretData is called with a KafkaAccess resource and the referenced KafkaUser resource is missing, " +
+            "then it throws an exception")
+    void testSecretDataMissingKafkaUser() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(
+                        ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false),
+                        ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())
+                ),
+                List.of(
+                        ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092),
+                        ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093)
+                )
+        );
+        Crds.kafkaOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafka).create();
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
+
+        assertThrows(IllegalStateException.class, () -> new KafkaAccessReconciler(client).secretData(kafkaAccess.getSpec(), NAMESPACE));
+    }
+
+    private static Stream<KafkaUserReference> userReferences() {
+        return Stream.of(
+                ResourceProvider.getUserReference("SpecialUser", KafkaUser.RESOURCE_GROUP, KAFKA_NAME, KAFKA_NAMESPACE),
+                ResourceProvider.getUserReference(KafkaUser.RESOURCE_KIND, "special.user.group", KAFKA_NAME, KAFKA_NAMESPACE),
+                ResourceProvider.getUserReference("SpecialUser", "special.user.group", KAFKA_NAME, KAFKA_NAMESPACE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("userReferences")
+    @DisplayName("When secretData is called with a KafkaAccess resource that references a user that has an invalid kind or apiGroup, " +
+            "then it throws an exception")
+    void testInvalidUserReference(KafkaUserReference userReference) {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(
+                        ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false),
+                        ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())
+                ),
+                List.of(
+                        ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092),
+                        ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093)
+                )
+        );
+        Crds.kafkaOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafka).create();
+
+        final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithoutStatus(KAFKA_NAME, KAFKA_NAMESPACE, new KafkaUserScramSha512ClientAuthentication());
+        Crds.kafkaUserOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafkaUser).create();
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, userReference);
+
+        assertThrows(IllegalStateException.class, () -> new KafkaAccessReconciler(client).secretData(kafkaAccess.getSpec(), NAMESPACE));
+    }
+}


### PR DESCRIPTION
Refactor tests so the reconciler tests don't
call reconcile directly, but instead create
an operator and let it automatically detect
when to reconcile.

Create new test class for tests against the
secret data returned.

Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>