### PR TITLE
fix: Add event source for Strimzi user secrets

### DIFF
--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -199,25 +199,25 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
         LOGGER.info("Preparing event sources");
         InformerEventSource<Kafka, KafkaAccess> kafkaEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(Kafka.class, context)
-                        .withSecondaryToPrimaryMapper(kafka -> KafkaAccessParser.getKafkaAccessSetForKafka(context.getPrimaryCache().list(), kafka))
+                        .withSecondaryToPrimaryMapper(kafka -> KafkaAccessParser.kafkaSecondaryToPrimaryMapper(context.getPrimaryCache().list(), kafka))
                         .build(),
                 context);
         InformerEventSource<KafkaUser, KafkaAccess> kafkaUserEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(KafkaUser.class, context)
-                        .withSecondaryToPrimaryMapper(kafkaUser -> KafkaAccessParser.getKafkaAccessSetForKafkaUser(context.getPrimaryCache().list(), kafkaUser))
-                        .withPrimaryToSecondaryMapper(kafkaAccess -> KafkaAccessParser.getKafkaUserForKafkaAccess((KafkaAccess) kafkaAccess))
+                        .withSecondaryToPrimaryMapper(kafkaUser -> KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(context.getPrimaryCache().list(), kafkaUser))
+                        .withPrimaryToSecondaryMapper(kafkaAccess -> KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper((KafkaAccess) kafkaAccess))
                         .build(),
                 context);
         InformerEventSource<Secret, KafkaAccess> strimziSecretEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(Secret.class)
                         .withLabelSelector(String.format("%s=%s", KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_CLUSTER_LABEL_VALUE))
-                        .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.getKafkaAccessResourceIDsForSecret(context.getPrimaryCache().list(), secret))
+                        .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
         InformerEventSource<Secret, KafkaAccess> kafkaAccessSecretEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(Secret.class)
                         .withLabelSelector(String.format("%s=%s", KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.KAFKA_ACCESS_LABEL_VALUE))
-                        .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.getKafkaAccessResourceIDsForSecret(context.getPrimaryCache().list(), secret))
+                        .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
         Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(kafkaEventSource, kafkaUserEventSource, strimziSecretEventSource);

--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -214,13 +214,19 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
                         .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
+        InformerEventSource<Secret, KafkaAccess> strimziKafkaUserSecretEventSource = new InformerEventSource<>(
+                InformerConfiguration.from(Secret.class)
+                        .withLabelSelector(String.format("%s=%s", KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_USER_LABEL_VALUE))
+                        .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
+                        .build(),
+                context);
         InformerEventSource<Secret, KafkaAccess> kafkaAccessSecretEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(Secret.class)
                         .withLabelSelector(String.format("%s=%s", KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.KAFKA_ACCESS_LABEL_VALUE))
                         .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
-        Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(kafkaEventSource, kafkaUserEventSource, strimziSecretEventSource);
+        Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(kafkaEventSource, kafkaUserEventSource, strimziSecretEventSource, strimziKafkaUserSecretEventSource);
         eventSources.put(ACCESS_SECRET_EVENT_SOURCE, kafkaAccessSecretEventSource);
         LOGGER.info("Finished preparing event sources");
         return eventSources;

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaAccessParser.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaAccessParser.java
@@ -44,9 +44,19 @@ public class KafkaAccessParser {
     public static final String INSTANCE_LABEL_KEY = "app.kubernetes.io/instance";
 
     /**
+     *  The constant for Strimzi cluster label
+     */
+    public static final String STRIMZI_CLUSTER_LABEL_KEY = "strimzi.io/cluster";
+
+    /**
      * The constant for Strimzi cluster operator label
      */
     public static final String STRIMZI_CLUSTER_LABEL_VALUE = "strimzi-cluster-operator";
+
+    /**
+     * The constant for Strimzi user operator label
+     */
+    public static final String STRIMZI_USER_LABEL_VALUE = "strimzi-user-operator";
 
     /**
      * The constant for Strimzi access operator label
@@ -146,28 +156,38 @@ public class KafkaAccessParser {
                 .map(ObjectMeta::getLabels)
                 .orElse(new HashMap<>());
 
-        if (KAFKA_ACCESS_LABEL_VALUE.equals(labels.get(MANAGED_BY_LABEL_KEY))) {
-            Optional.ofNullable(secret.getMetadata())
-                .map(ObjectMeta::getOwnerReferences)
-                .orElse(Collections.emptyList())
-                .stream()
-                .filter(ownerReference -> KafkaAccess.KIND.equals(ownerReference.getKind()))
-                .findFirst()
-                .map(OwnerReference::getName)
-                .ifPresent(s -> resourceIDS.add(new ResourceID(s, secretNamespace.get())));
+        final String managedByLabel = labels.get(MANAGED_BY_LABEL_KEY);
+        if (managedByLabel == null) {
+            LOGGER.error("Secret missing managed-by label, returning empty list.");
+            return resourceIDS;
         }
-
-        if (STRIMZI_CLUSTER_LABEL_VALUE.equals(labels.get(MANAGED_BY_LABEL_KEY))) {
-            Optional.ofNullable(labels.get(INSTANCE_LABEL_KEY))
-                .ifPresent(clusterName -> {
-                    final Kafka kafka = new KafkaBuilder()
-                            .withNewMetadata()
-                            .withName(clusterName)
-                            .withNamespace(secretNamespace.get())
-                            .endMetadata()
-                            .build();
-                    resourceIDS.addAll(KafkaAccessParser.kafkaSecondaryToPrimaryMapper(kafkaAccessList, kafka));
-                });
+        if (KAFKA_ACCESS_LABEL_VALUE.equals(managedByLabel)) {
+            Optional.ofNullable(secret.getMetadata())
+                    .map(ObjectMeta::getOwnerReferences)
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .filter(ownerReference -> KafkaAccess.KIND.equals(ownerReference.getKind()))
+                    .findFirst()
+                    .map(OwnerReference::getName)
+                    .ifPresent(s -> resourceIDS.add(new ResourceID(s, secretNamespace.get())));
+        } else {
+            final String clusterName = switch (managedByLabel) {
+                case STRIMZI_CLUSTER_LABEL_VALUE -> labels.get(INSTANCE_LABEL_KEY);
+                case STRIMZI_USER_LABEL_VALUE -> labels.get(STRIMZI_CLUSTER_LABEL_KEY);
+                default -> {
+                    LOGGER.error("Secret managed by unknown resource {}.", managedByLabel);
+                    yield null;
+                }
+            };
+            if (clusterName != null) {
+                final Kafka kafka = new KafkaBuilder()
+                        .withNewMetadata()
+                        .withName(clusterName)
+                        .withNamespace(secretNamespace.get())
+                        .endMetadata()
+                        .build();
+                resourceIDS.addAll(KafkaAccessParser.kafkaSecondaryToPrimaryMapper(kafkaAccessList, kafka));
+            }
         }
 
         return resourceIDS;

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaAccessParser.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaAccessParser.java
@@ -63,7 +63,7 @@ public class KafkaAccessParser {
      *
      * @return                   Set of ResourceIDs for the KafkaAccess objects that reference the Kafka resource
      */
-    public static Set<ResourceID> getKafkaAccessSetForKafka(final Stream<KafkaAccess> kafkaAccessList, final Kafka kafka) {
+    public static Set<ResourceID> kafkaSecondaryToPrimaryMapper(final Stream<KafkaAccess> kafkaAccessList, final Kafka kafka) {
         final Optional<String> kafkaName = Optional.ofNullable(kafka.getMetadata()).map(ObjectMeta::getName);
         final Optional<String> kafkaNamespace = Optional.ofNullable(kafka.getMetadata()).map(ObjectMeta::getNamespace);
         if (kafkaName.isEmpty() || kafkaNamespace.isEmpty()) {
@@ -88,7 +88,7 @@ public class KafkaAccessParser {
      *
      * @return                   Set of ResourceIDs for the KafkaAccess objects that reference the KafkaUser resource
      */
-    public static Set<ResourceID> getKafkaAccessSetForKafkaUser(final Stream<KafkaAccess> kafkaAccessList, final KafkaUser kafkaUser) {
+    public static Set<ResourceID> kafkaUserSecondaryToPrimaryMapper(final Stream<KafkaAccess> kafkaAccessList, final KafkaUser kafkaUser) {
         final Optional<String> kafkaUserName = Optional.ofNullable(kafkaUser.getMetadata()).map(ObjectMeta::getName);
         final Optional<String> kafkaUserNamespace = Optional.ofNullable(kafkaUser.getMetadata()).map(ObjectMeta::getNamespace);
         if (kafkaUserName.isEmpty() || kafkaUserNamespace.isEmpty()) {
@@ -131,7 +131,7 @@ public class KafkaAccessParser {
      *
      * @return                   Set of ResourceIDs for the KafkaAccess objects that reference the Kafka resource
      */
-    public static Set<ResourceID> getKafkaAccessResourceIDsForSecret(final Stream<KafkaAccess> kafkaAccessList, final Secret secret) {
+    public static Set<ResourceID> secretSecondaryToPrimaryMapper(final Stream<KafkaAccess> kafkaAccessList, final Secret secret) {
         final Set<ResourceID> resourceIDS = new HashSet<>();
 
         final Optional<String> secretNamespace = Optional.ofNullable(secret.getMetadata())
@@ -166,7 +166,7 @@ public class KafkaAccessParser {
                             .withNamespace(secretNamespace.get())
                             .endMetadata()
                             .build();
-                    resourceIDS.addAll(KafkaAccessParser.getKafkaAccessSetForKafka(kafkaAccessList, kafka));
+                    resourceIDS.addAll(KafkaAccessParser.kafkaSecondaryToPrimaryMapper(kafkaAccessList, kafka));
                 });
         }
 
@@ -180,7 +180,7 @@ public class KafkaAccessParser {
      *
      * @return               Set of ResourceIDs containing the KafkaUser that is referenced by the KafkaAccess
      */
-    public static Set<ResourceID> getKafkaUserForKafkaAccess(final KafkaAccess kafkaAccess) {
+    public static Set<ResourceID> kafkaUserPrimaryToSecondaryMapper(final KafkaAccess kafkaAccess) {
         final Set<ResourceID> resourceIDS = new HashSet<>();
         Optional.ofNullable(kafkaAccess.getSpec())
                 .map(KafkaAccessSpec::getUser)

--- a/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
+++ b/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
@@ -87,10 +87,21 @@ public class ResourceProvider {
         final Map<String, String> labels = new HashMap<>();
         labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_CLUSTER_LABEL_VALUE);
         labels.put(KafkaAccessParser.INSTANCE_LABEL_KEY, kafkaInstanceName);
+        return buildSecret(secretName, secretNamespace, labels);
+    }
+
+    public static Secret getStrimziUserSecret(final String secretName, final String secretNamespace, final String kafkaInstanceName) {
+        final Map<String, String> labels = new HashMap<>();
+        labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_USER_LABEL_VALUE);
+        labels.put(KafkaAccessParser.STRIMZI_CLUSTER_LABEL_KEY, kafkaInstanceName);
+        return buildSecret(secretName, secretNamespace, labels);
+    }
+
+    private static Secret buildSecret(final String name, final String namespace, final Map<String, String> labels) {
         return new SecretBuilder()
                 .withNewMetadata()
-                    .withName(secretName)
-                    .withNamespace(secretNamespace)
+                    .withName(name)
+                    .withNamespace(namespace)
                     .withLabels(labels)
                 .endMetadata()
                 .build();

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessParserTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessParserTest.java
@@ -34,7 +34,7 @@ public class KafkaAccessParserTest {
     static final String NAMESPACE_2 = "my-namespace-2";
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafka() is called with a list of two KafkaAccess objects and one " +
+    @DisplayName("When kafkaSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and one " +
             "references the Kafka, then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForKafka() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -42,42 +42,42 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafka(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafka() is called with a list of two KafkaAccess objects and both " +
+    @DisplayName("When kafkaSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and both " +
             "reference the Kafka, then both KafkaAccess instances are returned")
     void testTwoCorrectKafkaAccessReturnedForKafka() {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafka(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1), new ResourceID(ACCESS_NAME_2, NAMESPACE_2));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafka() is called with a list of two KafkaAccess objects and the " +
+    @DisplayName("When kafkaSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and the " +
             "KafkaAccess doesn't explicitly list the namespace, then the KafkaAccess in the same namespace as the Kafka is returned")
     void testKafkaAccessInMatchingNamespaceReturnedForKafka() {
         final KafkaReference kafkaReferenceNullNamespace = ResourceProvider.getKafkaReference(KAFKA_NAME_1, null);
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReferenceNullNamespace);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReferenceNullNamespace);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafka(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafka() is called with a list of KafkaAccess objects and none " +
+    @DisplayName("When kafkaSecondaryToPrimaryMapper() is called with a list of KafkaAccess objects and none " +
             "reference the Kafka, then an empty set is returned")
     void testKafkaAccessNoneMatchKafka() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -85,14 +85,14 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafka(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_1));
         assertThat(matches).isEmpty();
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafkaUser() is called with a list of two KafkaAccess objects and one " +
+    @DisplayName("When kafkaUserSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and one " +
             "references the KafkaUser, then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForKafkaUser() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -102,14 +102,14 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2, kafkaUserReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafkaUser(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafkaUser() is called with a list of two KafkaAccess objects and both " +
+    @DisplayName("When kafkaUserSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and both " +
             "reference the KafkaUser, then both KafkaAccess instances are returned")
     void testTwoCorrectKafkaAccessReturnedForKafkaUser() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -118,14 +118,14 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafkaUser(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1), new ResourceID(ACCESS_NAME_2, NAMESPACE_2));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafkaUser() is called with a list of two KafkaAccess objects and the " +
+    @DisplayName("When kafkaUserSecondaryToPrimaryMapper() is called with a list of two KafkaAccess objects and the " +
             "KafkaAccess doesn't explicitly list the namespace, then the KafkaAccess in the same namespace as the KafkaUser is returned")
     void testKafkaAccessInMatchingNamespaceReturnedForKafkaUser() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -134,14 +134,14 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReferenceNullNamespace);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2, kafkaUserReferenceNullNamespace);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafkaUser(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessSetForKafkaUser() is called with a list of KafkaAccess objects and none " +
+    @DisplayName("When kafkaUserSecondaryToPrimaryMapper() is called with a list of KafkaAccess objects and none " +
             "reference the KafkaUser, then an empty set is returned")
     void testKafkaAccessNoneMatchKafkaUser() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_2);
@@ -150,37 +150,37 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessSetForKafkaUser(
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_1));
         assertThat(matches).isEmpty();
     }
 
     @Test
-    @DisplayName("When getKafkaAccessResourceIDsForSecret() is called with a secret that is managed by a KafkaAccess, " +
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is managed by a KafkaAccess, " +
             "then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForKafkaAccessSecret() {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessResourceIDsForSecret(
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getEmptyKafkaAccessSecret(SECRET_NAME, NAMESPACE_1, ACCESS_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessResourceIDsForSecret() is called with an empty cache and a secret that is managed " +
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with an empty cache and a secret that is managed " +
             "by a KafkaAccess, then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForKafkaAccessSecretEmptyCache() {
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessResourceIDsForSecret(
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
                 Stream.of(),
                 ResourceProvider.getEmptyKafkaAccessSecret(SECRET_NAME, NAMESPACE_1, ACCESS_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessResourceIDsForSecret() is called with a secret that is managed by Strimzi, " +
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is managed by Strimzi, " +
             "then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForStrimziSecret() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
@@ -188,14 +188,14 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessResourceIDsForSecret(
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getStrimziSecret(SECRET_NAME, NAMESPACE_1, KAFKA_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
     }
 
     @Test
-    @DisplayName("When getKafkaAccessResourceIDsForSecret() is called with a secret that is managed by an unknown operator, " +
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is managed by an unknown operator, " +
             "then an empty set is returned")
     void testEmptySetForSecretManagedByUnknown() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
@@ -213,14 +213,14 @@ public class KafkaAccessParserTest {
                 .endMetadata()
                 .build();
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessResourceIDsForSecret(
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 secret);
         assertThat(matches).isEmpty();
     }
 
     @Test
-    @DisplayName("When getKafkaAccessResourceIDsForSecret() is called with a secret that is not managed by any resource, " +
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is not managed by any resource, " +
             "then an empty set is returned")
     void testEmptySetForUnmanagedSecret() {
         final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
@@ -235,45 +235,45 @@ public class KafkaAccessParserTest {
                 .endMetadata()
                 .build();
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaAccessResourceIDsForSecret(
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 secret);
         assertThat(matches).isEmpty();
     }
 
     @Test
-    @DisplayName("When getKafkaUserForKafkaAccess() is called with a KafkaAccess that does not reference a KafkaUser, " +
+    @DisplayName("When kafkaUserPrimaryToSecondaryMapper() is called with a KafkaAccess that does not reference a KafkaUser, " +
             "then an empty set is returned")
     void testKafkaAccessWithMissingKafkaUser() {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaUserForKafkaAccess(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).isEmpty();
     }
 
     @Test
-    @DisplayName("When getKafkaUserForKafkaAccess() is called with a KafkaAccess that references a KafkaUser, " +
+    @DisplayName("When kafkaUserPrimaryToSecondaryMapper() is called with a KafkaAccess that references a KafkaUser, " +
             "then the returned set includes the KafkaUser")
     void testKafkaAccessWithKafkaUser() {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME_1, NAMESPACE_2);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaUserForKafkaAccess(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).hasSize(1);
         assertThat(matches).containsExactly(new ResourceID(KAFKA_USER_NAME_1, NAMESPACE_2));
     }
 
     @Test
-    @DisplayName("When getKafkaUserForKafkaAccess() is called with a KafkaAccess that references a KafkaUser but no namespace, " +
+    @DisplayName("When kafkaUserPrimaryToSecondaryMapper() is called with a KafkaAccess that references a KafkaUser but no namespace, " +
             "then the returned set includes the KafkaUser with the namespace of the KafkaAccess")
     void testKafkaAccessWithKafkaUserMissingNamespace() {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME_1, null);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.getKafkaUserForKafkaAccess(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).hasSize(1);
         assertThat(matches).containsExactly(new ResourceID(KAFKA_USER_NAME_1, NAMESPACE_1));
     }

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessParserTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessParserTest.java
@@ -195,6 +195,21 @@ public class KafkaAccessParserTest {
     }
 
     @Test
+    @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is managed by Strimzi User Operator, " +
+            "then the correct KafkaAccess is returned")
+    void testCorrectKafkaAccessReturnedForStrimziUserSecret() {
+        final KafkaReference kafkaReference1 = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
+        final KafkaReference kafkaReference2 = ResourceProvider.getKafkaReference(KAFKA_NAME_2, NAMESPACE_1);
+        final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
+        final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
+
+        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+                Stream.of(kafkaAccess1, kafkaAccess2),
+                ResourceProvider.getStrimziUserSecret(SECRET_NAME, NAMESPACE_1, KAFKA_NAME_1));
+        assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
+    }
+
+    @Test
     @DisplayName("When secretSecondaryToPrimaryMapper() is called with a secret that is managed by an unknown operator, " +
             "then an empty set is returned")
     void testEmptySetForSecretManagedByUnknown() {


### PR DESCRIPTION
* Add event source for Strimzi user secrets so that changes to these secrets trigger a reconcile.
* Rename mapper functions to use JOSDK "primaryToSecondary/secondaryToPrimary" terminology. 

Fixes #19 

Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>