### PR TITLE
feat: Update Java Operator SDK to 4.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
         <maven.assembly.version>3.3.0</maven.assembly.version>
 
         <!-- Runtime dependencies -->
-        <javaoperatorsdk.version>3.2.0</javaoperatorsdk.version>
-        <fabric8.version>6.1.1</fabric8.version>
+        <javaoperatorsdk.version>4.4.1</javaoperatorsdk.version>
+        <fabric8.version>6.7.2</fabric8.version>
         <strimzi.version>0.31.0</strimzi.version>
         <kafka.clients.version>3.0.0</kafka.clients.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
@@ -118,6 +118,17 @@
             <groupId>io.javaoperatorsdk</groupId>
             <artifactId>operator-framework-core</artifactId>
             <version>${javaoperatorsdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <version>${fabric8.version}</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -156,11 +167,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.clients.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>${javax-validation.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -311,6 +317,8 @@
                             <ignoredDependencies>
                                 <!-- Required to generate CRD file -->
                                 <ignoredDependency>io.fabric8:crd-generator-apt:jar:${fabric8.version}</ignoredDependency>
+                                <ignoredDependency>io.fabric8:generator-annotations:jar:${fabric8.version}</ignoredDependency>
+                                <ignoredDependency>io.fabric8:kubernetes-httpclient-jdk:jar:${fabric8.version}</ignoredDependency>
                                 <ignoredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredDependency>
                             </ignoredDependencies>
                         </configuration>

--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessOperator.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessOperator.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.kafka.access;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.javaoperatorsdk.operator.Operator;
 import io.strimzi.kafka.access.server.HealthServlet;
 import org.eclipse.jetty.server.Server;
@@ -28,9 +26,8 @@ public class KafkaAccessOperator {
      */
     public static void main(final String[] args) {
         LOGGER.info("Kafka Access operator starting");
-        final KubernetesClient client = new KubernetesClientBuilder().build();
-        final Operator operator = new Operator(client);
-        operator.register(new KafkaAccessReconciler(client));
+        final Operator operator = new Operator();
+        operator.register(new KafkaAccessReconciler(operator.getKubernetesClient()));
         operator.installShutdownHook();
         operator.start();
         Server server = new Server(HEALTH_CHECK_PORT);

--- a/src/main/java/io/strimzi/kafka/access/model/KafkaAccessSpec.java
+++ b/src/main/java/io/strimzi/kafka/access/model/KafkaAccessSpec.java
@@ -4,14 +4,14 @@
  */
 package io.strimzi.kafka.access.model;
 
-import javax.validation.constraints.NotNull;
+import io.fabric8.generator.annotation.Required;
 
 /**
  * The spec model of the KafkaAccess resource
  */
 public class KafkaAccessSpec {
 
-    @NotNull
+    @Required
     private KafkaReference kafka;
     private KafkaUserReference user;
 

--- a/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
+++ b/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
@@ -4,14 +4,14 @@
  */
 package io.strimzi.kafka.access.model;
 
-import javax.validation.constraints.NotNull;
+import io.fabric8.generator.annotation.Required;
 
 /**
  * The Kafka reference. Keeps state for a Kafka resource of Strimzi Kafka Operator
  */
 public class KafkaReference {
 
-    @NotNull
+    @Required
     private String name;
     private String namespace;
     private String listener;

--- a/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
+++ b/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
@@ -4,18 +4,18 @@
  */
 package io.strimzi.kafka.access.model;
 
-import javax.validation.constraints.NotNull;
+import io.fabric8.generator.annotation.Required;
 
 /**
  * The Kafka user reference, which keeps state for a KafkaUser resource of Strimzi Kafka Operator
  */
 public class KafkaUserReference {
 
-    @NotNull
+    @Required
     private String kind;
-    @NotNull
+    @Required
     private String apiGroup;
-    @NotNull
+    @Required
     private String name;
     private String namespace;
 

--- a/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
+++ b/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
@@ -66,8 +66,8 @@ public class KafkaAccessReconcilerTest {
 
     @BeforeEach
     void beforeEach() {
-        operator = new Operator(client);
-        operator.register(new KafkaAccessReconciler(client));
+        operator = new Operator(overrider -> overrider.withKubernetesClient(client));
+        operator.register(new KafkaAccessReconciler(operator.getKubernetesClient()));
         operator.start();
     }
 


### PR DESCRIPTION
* Update Java Operator SDK to 4.4.1.
* Use new recommended mechanism to instantiate operator with Kubernetes client.
* Update fabric CRD generation annotations from NotNull to Required.