### PR TITLE
feat: Update operator to use cached resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <!-- Test dependencies -->
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <assertj.version>3.21.0</assertj.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <distributionManagement>
@@ -216,6 +217,12 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
             <version>${fabric8.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -15,30 +15,18 @@ import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.KafkaUserAuthentication;
-import io.strimzi.api.kafka.model.KafkaUserSpec;
-import io.strimzi.api.kafka.model.status.KafkaUserStatus;
-import io.strimzi.kafka.access.internal.KafkaListener;
 import io.strimzi.kafka.access.internal.KafkaAccessParser;
-import io.strimzi.kafka.access.internal.KafkaUserData;
 import io.strimzi.kafka.access.model.BindingStatus;
 import io.strimzi.kafka.access.model.KafkaAccess;
-import io.strimzi.kafka.access.model.KafkaAccessSpec;
 import io.strimzi.kafka.access.model.KafkaAccessStatus;
-import io.strimzi.kafka.access.model.KafkaReference;
-import io.strimzi.kafka.access.model.KafkaUserReference;
-import io.strimzi.kafka.access.internal.KafkaParser;
-import io.strimzi.kafka.access.internal.CustomResourceParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -50,27 +38,24 @@ import java.util.Optional;
 @ControllerConfiguration
 public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSourceInitializer<KafkaAccess> {
 
-    private static final String TYPE_SECRET_KEY = "type";
-    private static final String TYPE_SECRET_VALUE = "kafka";
-    private static final String PROVIDER_SECRET_KEY = "provider";
-    private static final String PROVIDER_SECRET_VALUE = "strimzi";
-    private static final String SECRET_TYPE = "servicebinding.io/kafka";
-    private static final String ACCESS_SECRET_EVENT_SOURCE = "access-secret-event-source";
-
     private final KubernetesClient kubernetesClient;
-    private final Map<String, String> commonSecretData = new HashMap<>();
+    private InformerEventSource<Secret, KafkaAccess> kafkaAccessSecretEventSource;
+    private final SecretDependentResource secretDependentResource;
     private final Map<String, String> commonSecretLabels = new HashMap<>();
-
+    private static final String SECRET_TYPE = "servicebinding.io/kafka";
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaAccessOperator.class);
+
+    /**
+     * Name of the event source for KafkaUser Secret resources
+     */
+    public static final String KAFKA_USER_SECRET_EVENT_SOURCE = "KAFKA_USER_SECRET_EVENT_SOURCE";
 
     /**
      * @param kubernetesClient      The Kubernetes client
      */
     public KafkaAccessReconciler(final KubernetesClient kubernetesClient) {
         this.kubernetesClient = kubernetesClient;
-        final Base64.Encoder encoder = Base64.getEncoder();
-        commonSecretData.put(TYPE_SECRET_KEY, encoder.encodeToString(TYPE_SECRET_VALUE.getBytes(StandardCharsets.UTF_8)));
-        commonSecretData.put(PROVIDER_SECRET_KEY, encoder.encodeToString(PROVIDER_SECRET_VALUE.getBytes(StandardCharsets.UTF_8)));
+        secretDependentResource = new SecretDependentResource();
         commonSecretLabels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.KAFKA_ACCESS_LABEL_VALUE);
     }
 
@@ -88,8 +73,7 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
         final String kafkaAccessNamespace = kafkaAccess.getMetadata().getNamespace();
         LOGGER.info("Reconciling KafkaAccess {}/{}", kafkaAccessNamespace, kafkaAccessName);
 
-        final Map<String, String> data  = secretData(kafkaAccess.getSpec(), kafkaAccessNamespace);
-        createOrUpdateSecret(context, data, kafkaAccess);
+        createOrUpdateSecret(secretDependentResource.desired(kafkaAccess.getSpec(), kafkaAccessNamespace, context), kafkaAccess);
 
         final boolean bindingStatusCorrect = Optional.ofNullable(kafkaAccess.getStatus())
                 .map(KafkaAccessStatus::getBinding)
@@ -106,52 +90,13 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
         }
     }
 
-    protected Map<String, String> secretData(final KafkaAccessSpec spec, final String kafkaAccessNamespace) {
-        final KafkaReference kafkaReference = spec.getKafka();
-        final String kafkaClusterNamespace = Optional.ofNullable(kafkaReference.getNamespace()).orElse(kafkaAccessNamespace);
-        final Optional<KafkaUserReference> kafkaUserReference = Optional.ofNullable(spec.getUser());
-
-        final Kafka kafka = getKafka(kafkaReference.getName(), kafkaClusterNamespace);
-
-        final Map<String, String> data  = new HashMap<>(commonSecretData);
-        final KafkaListener listener;
-        try {
-            if (kafkaUserReference.isPresent()) {
-                if (!KafkaUser.RESOURCE_KIND.equals(kafkaUserReference.get().getKind()) || !KafkaUser.RESOURCE_GROUP.equals(kafkaUserReference.get().getApiGroup())) {
-                    throw new CustomResourceParseException(String.format("User kind must be %s and apiGroup must be %s", KafkaUser.RESOURCE_KIND, KafkaUser.RESOURCE_GROUP));
-                }
-                final String kafkaUserName = kafkaUserReference.get().getName();
-                final String kafkaUserNamespace = Optional.ofNullable(kafkaUserReference.get().getNamespace()).orElse(kafkaAccessNamespace);
-                final KafkaUser kafkaUser = getKafkaUser(kafkaUserName, kafkaUserNamespace);
-                final String kafkaUserType = Optional.ofNullable(kafkaUser)
-                        .map(KafkaUser::getSpec)
-                        .map(KafkaUserSpec::getAuthentication)
-                        .map(KafkaUserAuthentication::getType)
-                        .orElse(KafkaParser.USER_AUTH_UNDEFINED);
-                listener = KafkaParser.getKafkaListener(kafka, spec, kafkaUserType);
-                if (kafkaUser != null) {
-                    final KafkaUserData userData = Optional.ofNullable(kafkaUser.getStatus())
-                            .map(KafkaUserStatus::getSecret)
-                            .map(secretName -> kubernetesClient.secrets().inNamespace(kafkaUserNamespace).withName(secretName).get())
-                            .map(secret -> new KafkaUserData(kafkaUser).withSecret(secret))
-                            .orElse(new KafkaUserData(kafkaUser));
-                    data.putAll(userData.getConnectionSecretData());
-                }
-
-            } else {
-                listener = KafkaParser.getKafkaListener(kafka, spec);
-            }
-        } catch (CustomResourceParseException e) {
-            throw new IllegalStateException("Reconcile failed due to ParserException " + e.getMessage());
-        }
-        data.putAll(listener.getConnectionSecretData());
-        return data;
-    }
-
-    private void createOrUpdateSecret(final Context<KafkaAccess> context, final Map<String, String> data, final KafkaAccess kafkaAccess) {
+    private void createOrUpdateSecret(final Map<String, String> data, final KafkaAccess kafkaAccess) {
         final String kafkaAccessName = kafkaAccess.getMetadata().getName();
         final String kafkaAccessNamespace = kafkaAccess.getMetadata().getNamespace();
-        context.getSecondaryResource(Secret.class, ACCESS_SECRET_EVENT_SOURCE)
+        if (kafkaAccessSecretEventSource == null) {
+            throw new IllegalStateException("Event source for Kafka Access Secret not initialized, cannot reconcile");
+        }
+        kafkaAccessSecretEventSource.get(new ResourceID(kafkaAccessName, kafkaAccessNamespace))
                 .ifPresentOrElse(secret -> {
                     final Map<String, String> currentData = secret.getData();
                     if (!data.equals(currentData)) {
@@ -220,29 +165,20 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
                         .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
-        InformerEventSource<Secret, KafkaAccess> kafkaAccessSecretEventSource = new InformerEventSource<>(
+        kafkaAccessSecretEventSource = new InformerEventSource<>(
                 InformerConfiguration.from(Secret.class)
                         .withLabelSelector(String.format("%s=%s", KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.KAFKA_ACCESS_LABEL_VALUE))
                         .withSecondaryToPrimaryMapper(secret -> KafkaAccessParser.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
                         .build(),
                 context);
-        Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(kafkaEventSource, kafkaUserEventSource, strimziSecretEventSource, strimziKafkaUserSecretEventSource);
-        eventSources.put(ACCESS_SECRET_EVENT_SOURCE, kafkaAccessSecretEventSource);
+        Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(
+                kafkaEventSource,
+                kafkaUserEventSource,
+                strimziSecretEventSource,
+                kafkaAccessSecretEventSource
+        );
+        eventSources.put(KAFKA_USER_SECRET_EVENT_SOURCE, strimziKafkaUserSecretEventSource);
         LOGGER.info("Finished preparing event sources");
         return eventSources;
-    }
-
-    private Kafka getKafka(final String clusterName, final String namespace) {
-        return Crds.kafkaOperation(kubernetesClient)
-                .inNamespace(namespace)
-                .withName(clusterName)
-                .get();
-    }
-
-    private KafkaUser getKafkaUser(final String name, final String namespace) {
-        return Crds.kafkaUserOperation(kubernetesClient)
-                .inNamespace(namespace)
-                .withName(name)
-                .get();
     }
 }

--- a/src/main/java/io/strimzi/kafka/access/SecretDependentResource.java
+++ b/src/main/java/io/strimzi/kafka/access/SecretDependentResource.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.access;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.KafkaUserAuthentication;
+import io.strimzi.api.kafka.model.KafkaUserSpec;
+import io.strimzi.api.kafka.model.status.KafkaUserStatus;
+import io.strimzi.kafka.access.internal.CustomResourceParseException;
+import io.strimzi.kafka.access.internal.KafkaListener;
+import io.strimzi.kafka.access.internal.KafkaParser;
+import io.strimzi.kafka.access.internal.KafkaUserData;
+import io.strimzi.kafka.access.model.KafkaAccess;
+import io.strimzi.kafka.access.model.KafkaAccessSpec;
+import io.strimzi.kafka.access.model.KafkaReference;
+import io.strimzi.kafka.access.model.KafkaUserReference;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Class to represent the data in the Secret created by the operator
+ * In future updates this could be updated to implement the
+ * Java Operator SDK DependentResource class
+ */
+public class SecretDependentResource {
+
+    private static final String TYPE_SECRET_KEY = "type";
+    private static final String TYPE_SECRET_VALUE = "kafka";
+    private static final String PROVIDER_SECRET_KEY = "provider";
+    private static final String PROVIDER_SECRET_VALUE = "strimzi";
+    private final Map<String, String> commonSecretData = new HashMap<>();
+
+    /**
+     * Default constructor that initialises the common secret data
+     */
+    public SecretDependentResource() {
+        final Base64.Encoder encoder = Base64.getEncoder();
+        commonSecretData.put(TYPE_SECRET_KEY, encoder.encodeToString(TYPE_SECRET_VALUE.getBytes(StandardCharsets.UTF_8)));
+        commonSecretData.put(PROVIDER_SECRET_KEY, encoder.encodeToString(PROVIDER_SECRET_VALUE.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * The desired state of the data in the secret
+     * @param spec          The spec of the KafkaAccess resource being reconciled
+     * @param namespace     The namespace of the KafkaAccess resource being reconciled
+     * @param context       The event source context
+     * @return              The data for the Secret as a Map
+     */
+    public Map<String, String> desired(final KafkaAccessSpec spec, final String namespace, final Context<KafkaAccess> context) {
+        final KafkaReference kafkaReference = spec.getKafka();
+        final String kafkaClusterName = kafkaReference.getName();
+        final String kafkaClusterNamespace = Optional.ofNullable(kafkaReference.getNamespace()).orElse(namespace);
+        final InformerEventSource<Kafka, KafkaAccess> kafkaEventSource = (InformerEventSource<Kafka, KafkaAccess>) context.eventSourceRetriever().getResourceEventSourceFor(Kafka.class);
+        final Kafka kafka = kafkaEventSource.get(new ResourceID(kafkaClusterName, kafkaClusterNamespace))
+                .orElseThrow(() -> new IllegalStateException(String.format("Kafka %s/%s missing", kafkaClusterNamespace, kafkaClusterName)));
+        final Optional<KafkaUserReference> kafkaUserReference = Optional.ofNullable(spec.getUser());
+        final Map<String, String> data  = new HashMap<>(commonSecretData);
+        if (kafkaUserReference.isPresent()) {
+            if (!KafkaUser.RESOURCE_KIND.equals(kafkaUserReference.get().getKind()) || !KafkaUser.RESOURCE_GROUP.equals(kafkaUserReference.get().getApiGroup())) {
+                throw new CustomResourceParseException(String.format("User kind must be %s and apiGroup must be %s", KafkaUser.RESOURCE_KIND, KafkaUser.RESOURCE_GROUP));
+            }
+            final String kafkaUserName = kafkaUserReference.get().getName();
+            final String kafkaUserNamespace = Optional.ofNullable(kafkaUserReference.get().getNamespace()).orElse(namespace);
+            final KafkaUser kafkaUser = context.getSecondaryResource(KafkaUser.class)
+                    .orElseThrow(() -> new IllegalStateException(String.format("KafkaUser %s/%s missing", kafkaUserNamespace, kafkaUserName)));
+            final String userSecretName = Optional.ofNullable(kafkaUser.getStatus())
+                    .map(KafkaUserStatus::getSecret)
+                    .orElseThrow(() -> new IllegalStateException(String.format("Secret for KafkaUser %s/%s missing", kafkaUserNamespace, kafkaUserName)));
+            final InformerEventSource<Secret, KafkaAccess> kafkaUserSecretEventSource = (InformerEventSource<Secret, KafkaAccess>) context.eventSourceRetriever()
+                    .getResourceEventSourceFor(Secret.class, KafkaAccessReconciler.KAFKA_USER_SECRET_EVENT_SOURCE);
+            final Secret kafkaUserSecret = kafkaUserSecretEventSource.get(new ResourceID(userSecretName, kafkaUserNamespace))
+                    .orElseThrow(() -> new IllegalStateException(String.format("Secret for KafkaUser %s/%s missing", kafkaUserNamespace, kafkaUserName)));
+            data.putAll(secretDataWithUser(spec, kafka, kafkaUser, new KafkaUserData(kafkaUser).withSecret(kafkaUserSecret)));
+        } else {
+            data.putAll(secretData(spec, kafka));
+        }
+        return data;
+    }
+
+    protected Map<String, String> secretData(final KafkaAccessSpec spec, final Kafka kafka) {
+        final Map<String, String> data  = new HashMap<>(commonSecretData);
+        final KafkaListener listener;
+        try {
+            listener = KafkaParser.getKafkaListener(kafka, spec);
+        } catch (CustomResourceParseException e) {
+            throw new IllegalStateException("Reconcile failed due to ParserException " + e.getMessage());
+        }
+        data.putAll(listener.getConnectionSecretData());
+        return data;
+    }
+
+    protected Map<String, String> secretDataWithUser(final KafkaAccessSpec spec, final Kafka kafka, final KafkaUser kafkaUser, final KafkaUserData kafkaUserData) {
+        final Map<String, String> data  = new HashMap<>(commonSecretData);
+        final KafkaListener listener;
+        try {
+            final String kafkaUserType = Optional.ofNullable(kafkaUser.getSpec())
+                    .map(KafkaUserSpec::getAuthentication)
+                    .map(KafkaUserAuthentication::getType)
+                    .orElse(KafkaParser.USER_AUTH_UNDEFINED);
+            listener = KafkaParser.getKafkaListener(kafka, spec, kafkaUserType);
+            data.putAll(kafkaUserData.getConnectionSecretData());
+        } catch (CustomResourceParseException e) {
+            throw new IllegalStateException("Reconcile failed due to ParserException " + e.getMessage());
+        }
+        data.putAll(listener.getConnectionSecretData());
+        return data;
+    }
+}

--- a/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
+++ b/src/test/java/io/strimzi/kafka/access/ResourceProvider.java
@@ -27,7 +27,7 @@ import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatus;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
-import io.strimzi.kafka.access.internal.KafkaAccessParser;
+import io.strimzi.kafka.access.internal.KafkaAccessMapper;
 import io.strimzi.kafka.access.model.KafkaAccess;
 import io.strimzi.kafka.access.model.KafkaAccessSpec;
 import io.strimzi.kafka.access.model.KafkaReference;
@@ -69,7 +69,7 @@ public class ResourceProvider {
 
     public static Secret getEmptyKafkaAccessSecret(String secretName, String secretNamespace, String kafkaAccessName) {
         final Map<String, String> labels = new HashMap<>();
-        labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.KAFKA_ACCESS_LABEL_VALUE);
+        labels.put(KafkaAccessMapper.MANAGED_BY_LABEL_KEY, KafkaAccessMapper.KAFKA_ACCESS_LABEL_VALUE);
         final OwnerReference ownerReference = new OwnerReference();
         ownerReference.setName(kafkaAccessName);
         ownerReference.setKind(KafkaAccess.KIND);
@@ -85,15 +85,15 @@ public class ResourceProvider {
 
     public static Secret getStrimziSecret(final String secretName, final String secretNamespace, final String kafkaInstanceName) {
         final Map<String, String> labels = new HashMap<>();
-        labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_CLUSTER_LABEL_VALUE);
-        labels.put(KafkaAccessParser.INSTANCE_LABEL_KEY, kafkaInstanceName);
+        labels.put(KafkaAccessMapper.MANAGED_BY_LABEL_KEY, KafkaAccessMapper.STRIMZI_CLUSTER_LABEL_VALUE);
+        labels.put(KafkaAccessMapper.INSTANCE_LABEL_KEY, kafkaInstanceName);
         return buildSecret(secretName, secretNamespace, labels);
     }
 
     public static Secret getStrimziUserSecret(final String secretName, final String secretNamespace, final String kafkaInstanceName) {
         final Map<String, String> labels = new HashMap<>();
-        labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, KafkaAccessParser.STRIMZI_USER_LABEL_VALUE);
-        labels.put(KafkaAccessParser.STRIMZI_CLUSTER_LABEL_KEY, kafkaInstanceName);
+        labels.put(KafkaAccessMapper.MANAGED_BY_LABEL_KEY, KafkaAccessMapper.STRIMZI_USER_LABEL_VALUE);
+        labels.put(KafkaAccessMapper.STRIMZI_CLUSTER_LABEL_KEY, kafkaInstanceName);
         return buildSecret(secretName, secretNamespace, labels);
     }
 

--- a/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
+++ b/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.access;
 
+import io.fabric8.kubernetes.api.model.Secret;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -46,6 +47,8 @@ public class SecretDependentResourceTest {
     private static final String LISTENER_2 = "listener-2";
     private static final String BOOTSTRAP_HOST = "my-kafka-name.svc";
     private static final String KAFKA_NAME = "my-kafka-name";
+    private static final String KAFKA_USER_NAME = "my-kafka-user";
+    private static final String KAFKA_USER_SECRET_NAME = "my-user-secret";
     private static final String KAFKA_NAMESPACE = "kafka-namespace";
     private static final int BOOTSTRAP_PORT_9092 = 9092;
     private static final int BOOTSTRAP_PORT_9093 = 9093;
@@ -101,26 +104,84 @@ public class SecretDependentResourceTest {
     }
 
     @Test
-    @DisplayName("When secretData is called with a KafkaAccess resource and the referenced Kafka resource is missing, " +
+    @DisplayName("When desired is called with a KafkaAccess resource and the referenced Kafka resource is missing, " +
             "then it throws an exception")
-    void testSecretDataMissingKafka() {
+    void testDesiredMissingKafka() {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
 
         final Context<KafkaAccess> mockContext = mock(Context.class);
-        final EventSourceRetriever<KafkaAccess> mockEventSourceRetriever = mock(EventSourceRetriever.class);
-        final InformerEventSource<Kafka, KafkaAccess> mockEventSource = mock(InformerEventSource.class);
-        when(mockContext.eventSourceRetriever()).thenReturn(mockEventSourceRetriever);
-        when(mockEventSourceRetriever.getResourceEventSourceFor(Kafka.class)).thenReturn(mockEventSource);
-        when(mockEventSource.get(any(ResourceID.class))).thenReturn(Optional.empty());
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.empty());
 
-        assertThrows(IllegalStateException.class, () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        assertThat(exception).hasMessage(String.format("Kafka %s/%s missing", KAFKA_NAMESPACE, KAFKA_NAME));
     }
 
     @Test
-    @DisplayName("When secretData is called with a KafkaAccess resource and the referenced KafkaUser resource is missing, " +
+    @DisplayName("When desired is called with a KafkaAccess resource and the referenced KafkaUser resource is missing, " +
             "then it throws an exception")
-    void testSecretDataMissingKafkaUser() {
+    void testDesiredMissingKafkaUser() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(
+                        ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false),
+                        ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())
+                ),
+                List.of(
+                        ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092),
+                        ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093)
+                )
+        );
+        final Context<KafkaAccess> mockContext = mock(Context.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
+        when(mockContext.getSecondaryResource(KafkaUser.class)).thenReturn(Optional.empty());
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        assertThat(exception).hasMessage(String.format("KafkaUser %s/%s missing", KAFKA_NAMESPACE, KAFKA_USER_NAME));
+    }
+
+    @Test
+    @DisplayName("When desired is called with a KafkaAccess resource and the referenced KafkaUser resource's status is missing the secret name, " +
+            "then it throws an exception")
+    void testDesiredMissingKafkaUserSecretName() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(
+                        ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false),
+                        ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())
+                ),
+                List.of(
+                        ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092),
+                        ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093)
+                )
+        );
+        final Context<KafkaAccess> mockContext = mock(Context.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
+
+        final KafkaUser kafkaUser = ResourceProvider.getKafkaUser(KAFKA_USER_NAME, KAFKA_NAMESPACE);
+        when(mockContext.getSecondaryResource(KafkaUser.class)).thenReturn(Optional.of(kafkaUser));
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        assertThat(exception).hasMessage(String.format("Secret in KafkaUser status %s/%s missing", KAFKA_NAMESPACE, KAFKA_USER_NAME));
+    }
+
+    @Test
+    @DisplayName("When desired is called with a KafkaAccess resource and the referenced KafkaUser resource's Secret, " +
+            "then it throws an exception")
+    void testDesiredMissingKafkaUserSecret() {
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -135,20 +196,22 @@ public class SecretDependentResourceTest {
         );
         final Context<KafkaAccess> mockContext = mock(Context.class);
         final EventSourceRetriever<KafkaAccess> mockEventSourceRetriever = mock(EventSourceRetriever.class);
-        final InformerEventSource<Kafka, KafkaAccess> mockKafkaEventSource = mock(InformerEventSource.class);
+        final InformerEventSource<Secret, KafkaAccess> mockInformerEventSource = mock(InformerEventSource.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
         when(mockContext.eventSourceRetriever()).thenReturn(mockEventSourceRetriever);
-        when(mockEventSourceRetriever.getResourceEventSourceFor(Kafka.class)).thenReturn(mockKafkaEventSource);
-        when(mockKafkaEventSource.get(any(ResourceID.class))).thenReturn(Optional.of(kafka));
+        when(mockEventSourceRetriever.getResourceEventSourceFor(Secret.class, KafkaAccessReconciler.KAFKA_USER_SECRET_EVENT_SOURCE)).thenReturn(mockInformerEventSource);
+        when(mockInformerEventSource.get(any(ResourceID.class))).thenReturn(Optional.empty());
+
+        final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(KAFKA_USER_NAME, KAFKA_NAMESPACE, KAFKA_USER_SECRET_NAME, "user", new KafkaUserScramSha512ClientAuthentication());
+        when(mockContext.getSecondaryResource(KafkaUser.class)).thenReturn(Optional.of(kafkaUser));
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
-        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
 
-        final InformerEventSource<KafkaUser, KafkaAccess> mockKafkaUserEventSource = mock(InformerEventSource.class);
-        when(mockEventSourceRetriever.getResourceEventSourceFor(KafkaUser.class)).thenReturn(mockKafkaUserEventSource);
-        when(mockKafkaUserEventSource.get(any(ResourceID.class))).thenReturn(Optional.empty());
-
-        assertThrows(IllegalStateException.class, () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        assertThat(exception).hasMessage(String.format("Secret %s for KafkaUser %s/%s missing", KAFKA_USER_SECRET_NAME, KAFKA_NAMESPACE, KAFKA_USER_NAME));
     }
 
     private static Stream<KafkaUserReference> userReferences() {
@@ -176,20 +239,12 @@ public class SecretDependentResourceTest {
                 )
         );
         final Context<KafkaAccess> mockContext = mock(Context.class);
-        final EventSourceRetriever<KafkaAccess> mockEventSourceRetriever = mock(EventSourceRetriever.class);
-        final InformerEventSource<Kafka, KafkaAccess> mockKafkaEventSource = mock(InformerEventSource.class);
-        when(mockContext.eventSourceRetriever()).thenReturn(mockEventSourceRetriever);
-        when(mockEventSourceRetriever.getResourceEventSourceFor(Kafka.class)).thenReturn(mockKafkaEventSource);
-        when(mockKafkaEventSource.get(any(ResourceID.class))).thenReturn(Optional.of(kafka));
-
-        final KafkaUser kafkaUser = ResourceProvider.getKafkaUser(KAFKA_NAME, KAFKA_NAMESPACE, new KafkaUserScramSha512ClientAuthentication());
-        final InformerEventSource<KafkaUser, KafkaAccess> mockKafkaUserEventSource = mock(InformerEventSource.class);
-        when(mockEventSourceRetriever.getResourceEventSourceFor(KafkaUser.class)).thenReturn(mockKafkaUserEventSource);
-        when(mockKafkaUserEventSource.get(any(ResourceID.class))).thenReturn(Optional.of(kafkaUser));
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, userReference);
-
-        assertThrows(CustomResourceParseException.class, () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class,
+                () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
+        assertThat(exception).hasMessage("User kind must be KafkaUser and apiGroup must be kafka.strimzi.io");
     }
 }

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaAccessMapperTest.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KafkaAccessParserTest {
+public class KafkaAccessMapperTest {
 
     static final String ACCESS_NAME_1 = "my-access-1";
     static final String ACCESS_NAME_2 = "my-access-2";
@@ -42,7 +42,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -56,7 +56,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1), new ResourceID(ACCESS_NAME_2, NAMESPACE_2));
@@ -70,7 +70,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReferenceNullNamespace);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReferenceNullNamespace);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -85,7 +85,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafka(KAFKA_NAME_1, NAMESPACE_1));
         assertThat(matches).isEmpty();
@@ -102,7 +102,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2, kafkaUserReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -118,7 +118,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_2));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1), new ResourceID(ACCESS_NAME_2, NAMESPACE_2));
@@ -134,7 +134,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReferenceNullNamespace);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2, kafkaUserReferenceNullNamespace);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -150,7 +150,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1, kafkaUserReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_2, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getKafkaUser(KAFKA_USER_NAME_1, NAMESPACE_1));
         assertThat(matches).isEmpty();
@@ -163,7 +163,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1);
 
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getEmptyKafkaAccessSecret(SECRET_NAME, NAMESPACE_1, ACCESS_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -173,7 +173,7 @@ public class KafkaAccessParserTest {
     @DisplayName("When secretSecondaryToPrimaryMapper() is called with an empty cache and a secret that is managed " +
             "by a KafkaAccess, then the correct KafkaAccess is returned")
     void testCorrectKafkaAccessReturnedForKafkaAccessSecretEmptyCache() {
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(),
                 ResourceProvider.getEmptyKafkaAccessSecret(SECRET_NAME, NAMESPACE_1, ACCESS_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -188,7 +188,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getStrimziSecret(SECRET_NAME, NAMESPACE_1, KAFKA_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -203,7 +203,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess1 = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference1);
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 ResourceProvider.getStrimziUserSecret(SECRET_NAME, NAMESPACE_1, KAFKA_NAME_1));
         assertThat(matches).containsExactly(new ResourceID(ACCESS_NAME_1, NAMESPACE_1));
@@ -219,7 +219,7 @@ public class KafkaAccessParserTest {
         final KafkaAccess kafkaAccess2 = ResourceProvider.getKafkaAccess(ACCESS_NAME_2, NAMESPACE_1, kafkaReference2);
 
         final Map<String, String> labels = new HashMap<>();
-        labels.put(KafkaAccessParser.MANAGED_BY_LABEL_KEY, "unknown");
+        labels.put(KafkaAccessMapper.MANAGED_BY_LABEL_KEY, "unknown");
         final Secret secret = new SecretBuilder()
                 .withNewMetadata()
                 .withName(SECRET_NAME)
@@ -228,7 +228,7 @@ public class KafkaAccessParserTest {
                 .endMetadata()
                 .build();
 
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 secret);
         assertThat(matches).isEmpty();
@@ -250,7 +250,7 @@ public class KafkaAccessParserTest {
                 .endMetadata()
                 .build();
 
-        final Set<ResourceID> matches = KafkaAccessParser.secretSecondaryToPrimaryMapper(
+        final Set<ResourceID> matches = KafkaAccessMapper.secretSecondaryToPrimaryMapper(
                 Stream.of(kafkaAccess1, kafkaAccess2),
                 secret);
         assertThat(matches).isEmpty();
@@ -263,7 +263,7 @@ public class KafkaAccessParserTest {
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).isEmpty();
     }
 
@@ -275,7 +275,7 @@ public class KafkaAccessParserTest {
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME_1, NAMESPACE_2);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).hasSize(1);
         assertThat(matches).containsExactly(new ResourceID(KAFKA_USER_NAME_1, NAMESPACE_2));
     }
@@ -288,8 +288,32 @@ public class KafkaAccessParserTest {
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME_1, null);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_1, kafkaReference, kafkaUserReference);
 
-        final Set<ResourceID> matches = KafkaAccessParser.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaUserPrimaryToSecondaryMapper(kafkaAccess);
         assertThat(matches).hasSize(1);
         assertThat(matches).containsExactly(new ResourceID(KAFKA_USER_NAME_1, NAMESPACE_1));
+    }
+
+    @Test
+    @DisplayName("When kafkaPrimaryToSecondaryMapper() is called with a KafkaAccess, " +
+            "then the returned set includes the Kafka that is referenced")
+    void testKafkaAccessWithKafka() {
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, NAMESPACE_1);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_2, kafkaReference);
+
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaPrimaryToSecondaryMapper(kafkaAccess);
+        assertThat(matches).hasSize(1);
+        assertThat(matches).containsExactly(new ResourceID(KAFKA_NAME_1, NAMESPACE_1));
+    }
+
+    @Test
+    @DisplayName("When kafkaPrimaryToSecondaryMapper() is called with a KafkaAccess that references a Kafka but no namespace, " +
+            "then the returned set includes the Kafka with the namespace of the KafkaAccess")
+    void testKafkaAccessWithKafkaMissingNamespace() {
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME_1, null);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(ACCESS_NAME_1, NAMESPACE_2, kafkaReference);
+
+        final Set<ResourceID> matches = KafkaAccessMapper.kafkaPrimaryToSecondaryMapper(kafkaAccess);
+        assertThat(matches).hasSize(1);
+        assertThat(matches).containsExactly(new ResourceID(KAFKA_NAME_1, NAMESPACE_2));
     }
 }


### PR DESCRIPTION
* Update operator to use cached resources rather than calling Kubernetes directly.
* Move code to construct secret data into a separate class to make it easier to switch to DependentResource type later.
* Add primaryToSecondary mapper for Kafka and rename Mapper class.

Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>