### PR TITLE
feat: Add certificate files to KafkaAccess secret

### DIFF
--- a/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -46,6 +46,11 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaAccessOperator.class);
 
     /**
+     * Name of the event source for Strimzi Secret resources
+     */
+    public static final String STRIMZI_SECRET_EVENT_SOURCE = "STRIMZI_SECRET_EVENT_SOURCE";
+
+    /**
      * Name of the event source for KafkaUser Secret resources
      */
     public static final String KAFKA_USER_SECRET_EVENT_SOURCE = "KAFKA_USER_SECRET_EVENT_SOURCE";
@@ -175,9 +180,9 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess>, EventSour
         Map<String, EventSource> eventSources = EventSourceInitializer.nameEventSources(
                 kafkaEventSource,
                 kafkaUserEventSource,
-                strimziSecretEventSource,
                 kafkaAccessSecretEventSource
         );
+        eventSources.put(STRIMZI_SECRET_EVENT_SOURCE, strimziSecretEventSource);
         eventSources.put(KAFKA_USER_SECRET_EVENT_SOURCE, strimziKafkaUserSecretEventSource);
         LOGGER.info("Finished preparing event sources");
         return eventSources;

--- a/src/main/java/io/strimzi/kafka/access/SecretDependentResource.java
+++ b/src/main/java/io/strimzi/kafka/access/SecretDependentResource.java
@@ -110,7 +110,7 @@ public class SecretDependentResource {
                 .getResourceEventSourceFor(Secret.class, KafkaAccessReconciler.STRIMZI_SECRET_EVENT_SOURCE);
         return strimziSecretEventSource.get(new ResourceID(caCertSecretName, kafkaClusterNamespace))
                 .map(Secret::getData)
-                .orElse(new HashMap<>());
+                .orElse(Map.of());
     }
 
     private static Supplier<IllegalStateException> illegalStateException(String type, String namespace, String name) {

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
@@ -30,6 +30,7 @@ public class KafkaListener {
     private final boolean tls;
     private final String authenticationType;
     private String bootstrapServer;
+    private Map<String, String> caCertSecret;
 
     /**
      * Constructor
@@ -51,6 +52,17 @@ public class KafkaListener {
      */
     public KafkaListener withBootstrapServer(final String bootstrapServer) {
         this.bootstrapServer = bootstrapServer;
+        return this;
+    }
+
+    /**
+     * Decorates a KafkaListener instance with boostrap server information
+     *
+     * @param caCertSecret The CA certificate secret
+     * @return  A decorated KafkaListener instance
+     */
+    public KafkaListener withCaCertSecret(final Map<String, String> caCertSecret) {
+        this.caCertSecret = caCertSecret;
         return this;
     }
 
@@ -117,6 +129,9 @@ public class KafkaListener {
         data.put("securityProtocol", encodedSecurityProtocol);
         //Spring settings
         data.put("bootstrap-servers", bootstrapServers);
+        if (this.tls) {
+            Optional.ofNullable(this.caCertSecret).map(secretData -> secretData.get("ca.crt")).ifPresent(cert -> data.put("ssl.truststore.crt", cert));
+        }
         return data;
     }
 

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
@@ -130,7 +130,9 @@ public class KafkaListener {
         //Spring settings
         data.put("bootstrap-servers", bootstrapServers);
         if (this.tls) {
-            Optional.ofNullable(this.caCertSecret).map(secretData -> secretData.get("ca.crt")).ifPresent(cert -> data.put("ssl.truststore.crt", cert));
+            Optional.ofNullable(this.caCertSecret)
+                    .map(secretData -> secretData.get("ca.crt"))
+                    .ifPresent(cert -> data.put("ssl.truststore.crt", cert));
         }
         return data;
     }

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaParser.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaParser.java
@@ -47,23 +47,11 @@ public class KafkaParser {
     public static final String USER_AUTH_UNDEFINED = "user-auth-undefined";
 
     /**
-     * Selects a KafkaListener from the Kafka resource based on the KafkaAccessSpec
-     *
-     * @param kafka                The Kafka resource
-     * @param kafkaAccessSpec      The KafkaAccessSpec resource
-     *
-     * @return                     A new instance of KafkaListener for the chosen listener
-     */
-    public static KafkaListener getKafkaListener(final Kafka kafka, final KafkaAccessSpec kafkaAccessSpec) {
-        return getKafkaListener(kafka, kafkaAccessSpec, null);
-    }
-
-    /**
      * Selects a KafkaListener from the Kafka resource based on the KafkaAccessSpec and the request authentication type
      *
      * @param kafka                The Kafka resource
      * @param kafkaAccessSpec      The KafkaAccessSpec resource
-     * @param kafkaUserAuth        The KafkaUser authentication type
+     * @param kafkaUserAuth        The KafkaUser authentication type, can be null
      *
      * @return                     A new instance of KafkaListener for the chosen listener
      */

--- a/src/main/java/io/strimzi/kafka/access/internal/KafkaUserData.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/KafkaUserData.java
@@ -9,6 +9,8 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserSpec;
+import io.strimzi.api.kafka.model.KafkaUserTlsClientAuthentication;
+import io.strimzi.api.kafka.model.KafkaUserTlsExternalClientAuthentication;
 import io.strimzi.api.kafka.model.status.KafkaUserStatus;
 import org.apache.kafka.common.config.SaslConfigs;
 
@@ -75,6 +77,12 @@ public class KafkaUserData {
                     .ifPresent(password -> secretData.put("password", password));
             Optional.ofNullable(rawUserData.get(SaslConfigs.SASL_JAAS_CONFIG))
                     .ifPresent(jaasConfig -> secretData.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig));
+        }
+        if (KafkaUserTlsClientAuthentication.TYPE_TLS.equals(authType) || KafkaUserTlsExternalClientAuthentication.TYPE_TLS_EXTERNAL.equals(authType)) {
+            Optional.ofNullable(rawUserData.get("user.crt"))
+                    .ifPresent(cert -> secretData.put("ssl.keystore.crt", cert));
+            Optional.ofNullable(rawUserData.get("user.key"))
+                    .ifPresent(key -> secretData.put("ssl.keystore.key", key));
         }
         return secretData;
     }

--- a/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
+++ b/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
@@ -11,7 +11,7 @@ public class Base64Encoder {
 
     private static final Base64.Encoder ENCODER = Base64.getEncoder();
 
-    public static String encodeToString(String data) {
+    public static String encodeUtf8(String data) {
         return ENCODER.encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
+++ b/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.access;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class Base64Encoder {
+
+    private static final Base64.Encoder ENCODER = Base64.getEncoder();
+
+    public static String encodeToString(String data) {
+        return ENCODER.encodeToString(data.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
+++ b/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static io.strimzi.kafka.access.Base64Encoder.encodeToString;
+import static io.strimzi.kafka.access.Base64Encoder.encodeUtf8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 
@@ -121,10 +121,10 @@ public class KafkaAccessReconcilerTest {
         assertThat(ownerReferences).containsExactly(ownerReference);
 
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encodeToString("kafka"));
-        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put("type", encodeUtf8("kafka"));
+        expectedDataEntries.put("provider", encodeUtf8("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+                encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
         assertThat(secret.getData()).containsAllEntriesOf(expectedDataEntries);
     }
 
@@ -139,7 +139,7 @@ public class KafkaAccessReconcilerTest {
                 List.of(ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092))
         );
         final Secret certSecret = ResourceProvider.getStrimziSecret(KafkaResources.clusterCaCertificateSecretName(KAFKA_NAME), KAFKA_NAME, KAFKA_NAMESPACE);
-        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
         final Map<String, String> certSecretData = new HashMap<>();
         certSecretData.put("ca.crt", cert);
         certSecret.setData(certSecretData);
@@ -164,10 +164,10 @@ public class KafkaAccessReconcilerTest {
         assertThat(secret.getType()).isEqualTo("servicebinding.io/kafka");
 
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encodeToString("kafka"));
-        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put("type", encodeUtf8("kafka"));
+        expectedDataEntries.put("provider", encodeUtf8("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+                encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
         expectedDataEntries.put("ssl.truststore.crt", cert);
 
         assertThat(secret.getData()).containsAllEntriesOf(expectedDataEntries);
@@ -177,8 +177,8 @@ public class KafkaAccessReconcilerTest {
     @DisplayName("When reconcile is called with a KafkaAccess resource that references a KafkaUser, then a secret is created with the " +
             "bootstrapServer for the correct listener and the KafkaAccess status is updated")
     void testReconcileWithKafkaUser() {
-        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
-        final String key = encodeToString("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
+        final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String key = encodeUtf8("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -222,7 +222,7 @@ public class KafkaAccessReconcilerTest {
         assertThat(secret.getData())
                 .containsEntry(
                         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                        encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
+                        encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
                 ).containsEntry("ssl.keystore.crt", cert)
                 .containsEntry("ssl.keystore.key", key);
     }
@@ -232,11 +232,11 @@ public class KafkaAccessReconcilerTest {
             "bootstrapServer for the correct listener, the SASL username, password and Jaas config, and the KafkaAccess status is updated")
     void testReconcileWithSASLKafkaUser() {
         final String username = "my-user";
-        final String encodedUsername = encodeToString(username);
+        final String encodedUsername = encodeUtf8(username);
         final String password = "password";
-        final String encodedPassword = encodeToString(password);
+        final String encodedPassword = encodeUtf8(password);
         final String saslJaasConfig = String.format("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";", username, password);
-        final String encodedSaslJaasConfig = encodeToString(saslJaasConfig);
+        final String encodedSaslJaasConfig = encodeUtf8(saslJaasConfig);
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -280,7 +280,7 @@ public class KafkaAccessReconcilerTest {
         assertThat(secret.getData())
                 .containsEntry(
                         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                        encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
+                        encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
                 )
                 .containsEntry("username", encodedUsername)
                 .containsEntry("user", encodedUsername)
@@ -317,8 +317,8 @@ public class KafkaAccessReconcilerTest {
         }, TEST_TIMEOUT, TimeUnit.MILLISECONDS);
 
         final Secret updatedSecret = client.secrets().inNamespace(NAMESPACE).withName(NAME).get();
-        assertThat(updatedSecret.getData()).contains(entry("type", encodeToString("kafka")),
-                entry("provider", encodeToString("strimzi")));
+        assertThat(updatedSecret.getData()).contains(entry("type", encodeUtf8("kafka")),
+                entry("provider", encodeUtf8("strimzi")));
         assertThat(updatedSecret.getMetadata().getAnnotations()).containsAllEntriesOf(customAnnotation);
     }
 }

--- a/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
+++ b/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.KafkaUserTlsExternalClientAuthentication;
@@ -32,8 +33,6 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -41,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static io.strimzi.kafka.access.Base64Encoder.encodeToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 
@@ -120,12 +120,56 @@ public class KafkaAccessReconcilerTest {
                 .build();
         assertThat(ownerReferences).containsExactly(ownerReference);
 
-        final Base64.Encoder encoder = Base64.getEncoder();
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encoder.encodeToString("kafka".getBytes(StandardCharsets.UTF_8)));
-        expectedDataEntries.put("provider", encoder.encodeToString("strimzi".getBytes(StandardCharsets.UTF_8)));
+        expectedDataEntries.put("type", encodeToString("kafka"));
+        expectedDataEntries.put("provider", encodeToString("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092).getBytes(StandardCharsets.UTF_8)));
+                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+        assertThat(secret.getData()).containsAllEntriesOf(expectedDataEntries);
+    }
+
+    @Test
+    @DisplayName("When reconcile is called with a KafkaAccess resource that references a tls listener, then a secret is created with the " +
+            "CA certificate and the KafkaAccess status is updated")
+    void testReconcileTlsListener() {
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true)),
+                List.of(ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092))
+        );
+        final Secret certSecret = ResourceProvider.getStrimziSecret(KafkaResources.clusterCaCertificateSecretName(KAFKA_NAME), KAFKA_NAME, KAFKA_NAMESPACE);
+        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", cert);
+        certSecret.setData(certSecretData);
+
+        Crds.kafkaOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafka).create();
+        client.secrets().inNamespace(KAFKA_NAMESPACE).resource(certSecret).create();
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReferenceWithListener(KAFKA_NAME, LISTENER_1, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
+
+        client.resources(KafkaAccess.class).resource(kafkaAccess).create();
+        client.resources(KafkaAccess.class).inNamespace(NAMESPACE).withName(NAME).waitUntilCondition(updatedKafkaAccess -> {
+            final Optional<String> bindingName = Optional.ofNullable(updatedKafkaAccess)
+                    .map(KafkaAccess::getStatus)
+                    .map(KafkaAccessStatus::getBinding)
+                    .map(BindingStatus::getName);
+            return bindingName.isPresent() && NAME.equals(bindingName.get());
+        }, TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+
+        final Secret secret = client.secrets().inNamespace(NAMESPACE).withName(NAME).get();
+        assertThat(secret).isNotNull();
+        assertThat(secret.getType()).isEqualTo("servicebinding.io/kafka");
+
+        final Map<String, String> expectedDataEntries = new HashMap<>();
+        expectedDataEntries.put("type", encodeToString("kafka"));
+        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+        expectedDataEntries.put("ssl.truststore.crt", cert);
+
         assertThat(secret.getData()).containsAllEntriesOf(expectedDataEntries);
     }
 
@@ -133,6 +177,8 @@ public class KafkaAccessReconcilerTest {
     @DisplayName("When reconcile is called with a KafkaAccess resource that references a KafkaUser, then a secret is created with the " +
             "bootstrapServer for the correct listener and the KafkaAccess status is updated")
     void testReconcileWithKafkaUser() {
+        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String key = encodeToString("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -151,6 +197,10 @@ public class KafkaAccessReconcilerTest {
         Crds.kafkaUserOperation(client).inNamespace(KAFKA_NAMESPACE).resource(kafkaUser).create();
 
         final Secret kafkaUserSecret = ResourceProvider.getStrimziUserSecret(KAFKA_USER_NAME, KAFKA_NAMESPACE, KAFKA_NAME);
+        final Map<String, String> kafkaUserSecretData = new HashMap<>();
+        kafkaUserSecretData.put("user.crt", cert);
+        kafkaUserSecretData.put("user.key", key);
+        kafkaUserSecret.setData(kafkaUserSecretData);
         client.secrets().inNamespace(KAFKA_NAMESPACE).resource(kafkaUserSecret).create();
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
@@ -169,24 +219,24 @@ public class KafkaAccessReconcilerTest {
         final Secret secret = client.secrets().inNamespace(NAMESPACE).withName(NAME).get();
         assertThat(secret).isNotNull();
 
-        final Base64.Encoder encoder = Base64.getEncoder();
-        assertThat(secret.getData()).containsEntry(
-                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093).getBytes(StandardCharsets.UTF_8))
-        );
+        assertThat(secret.getData())
+                .containsEntry(
+                        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                        encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
+                ).containsEntry("ssl.keystore.crt", cert)
+                .containsEntry("ssl.keystore.key", key);
     }
 
     @Test
     @DisplayName("When reconcile is called with a KafkaAccess resource that references a SASL KafkaUser, then a secret is created with the " +
             "bootstrapServer for the correct listener, the SASL username, password and Jaas config, and the KafkaAccess status is updated")
     void testReconcileWithSASLKafkaUser() {
-        final Base64.Encoder encoder = Base64.getEncoder();
         final String username = "my-user";
-        final String encodedUsername = encoder.encodeToString(username.getBytes(StandardCharsets.UTF_8));
+        final String encodedUsername = encodeToString(username);
         final String password = "password";
-        final String encodedPassword = encoder.encodeToString(password.getBytes(StandardCharsets.UTF_8));
+        final String encodedPassword = encodeToString(password);
         final String saslJaasConfig = String.format("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";", username, password);
-        final String encodedSaslJaasConfig = encoder.encodeToString(saslJaasConfig.getBytes(StandardCharsets.UTF_8));
+        final String encodedSaslJaasConfig = encodeToString(saslJaasConfig);
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -230,7 +280,7 @@ public class KafkaAccessReconcilerTest {
         assertThat(secret.getData())
                 .containsEntry(
                         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                        encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093).getBytes(StandardCharsets.UTF_8))
+                        encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
                 )
                 .containsEntry("username", encodedUsername)
                 .containsEntry("user", encodedUsername)
@@ -267,10 +317,8 @@ public class KafkaAccessReconcilerTest {
         }, TEST_TIMEOUT, TimeUnit.MILLISECONDS);
 
         final Secret updatedSecret = client.secrets().inNamespace(NAMESPACE).withName(NAME).get();
-        final Base64.Encoder encoder = Base64.getEncoder();
-        assertThat(updatedSecret.getData()).contains(entry("type", encoder.encodeToString("kafka".getBytes(StandardCharsets.UTF_8))),
-                entry("provider", encoder.encodeToString("strimzi".getBytes(StandardCharsets.UTF_8))));
+        assertThat(updatedSecret.getData()).contains(entry("type", encodeToString("kafka")),
+                entry("provider", encodeToString("strimzi")));
         assertThat(updatedSecret.getMetadata().getAnnotations()).containsAllEntriesOf(customAnnotation);
     }
-
 }

--- a/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
+++ b/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static io.strimzi.kafka.access.Base64Encoder.encodeToString;
+import static io.strimzi.kafka.access.Base64Encoder.encodeUtf8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,10 +71,10 @@ public class SecretDependentResourceTest {
 
         Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encodeToString("kafka"));
-        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put("type", encodeUtf8("kafka"));
+        expectedDataEntries.put("provider", encodeUtf8("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+                encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
         assertThat(data).containsAllEntriesOf(expectedDataEntries);
     }
 
@@ -82,7 +82,7 @@ public class SecretDependentResourceTest {
     @DisplayName("When secretData is called with a KafkaAccess resource that references a tls listener, then the data returned includes the " +
             "CA certificate")
     void testSecretDataWithTls() {
-        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
         final Map<String, String> certSecretData = new HashMap<>();
         certSecretData.put("ca.crt", cert);
         final Secret certSecret = ResourceProvider.getStrimziSecret(KafkaResources.clusterCaCertificateSecretName(KAFKA_NAME), KAFKA_NAMESPACE, KAFKA_NAME);
@@ -107,10 +107,10 @@ public class SecretDependentResourceTest {
 
         Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encodeToString("kafka"));
-        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put("type", encodeUtf8("kafka"));
+        expectedDataEntries.put("provider", encodeUtf8("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+                encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
         expectedDataEntries.put("ssl.truststore.crt", cert);
         assertThat(data).containsAllEntriesOf(expectedDataEntries);
     }
@@ -144,7 +144,7 @@ public class SecretDependentResourceTest {
         Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
         assertThat(data).containsEntry(
                 CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
+                encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
         );
     }
 

--- a/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
+++ b/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
@@ -10,12 +10,12 @@ import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.kafka.access.internal.CustomResourceParseException;
-import io.strimzi.kafka.access.internal.KafkaUserData;
 import io.strimzi.kafka.access.model.KafkaAccess;
 import io.strimzi.kafka.access.model.KafkaReference;
 import io.strimzi.kafka.access.model.KafkaUserReference;
@@ -25,14 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static io.strimzi.kafka.access.Base64Encoder.encodeToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,17 +63,55 @@ public class SecretDependentResourceTest {
                 List.of(ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, false)),
                 List.of(ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092))
         );
+        final Context<KafkaAccess> mockContext = mock(Context.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
 
-        Map<String, String> data = new SecretDependentResource().secretData(kafkaAccess.getSpec(), kafka);
-        final Base64.Encoder encoder = Base64.getEncoder();
+        Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
         final Map<String, String> expectedDataEntries = new HashMap<>();
-        expectedDataEntries.put("type", encoder.encodeToString("kafka".getBytes(StandardCharsets.UTF_8)));
-        expectedDataEntries.put("provider", encoder.encodeToString("strimzi".getBytes(StandardCharsets.UTF_8)));
+        expectedDataEntries.put("type", encodeToString("kafka"));
+        expectedDataEntries.put("provider", encodeToString("strimzi"));
         expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092).getBytes(StandardCharsets.UTF_8)));
+                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+        assertThat(data).containsAllEntriesOf(expectedDataEntries);
+    }
+
+    @Test
+    @DisplayName("When secretData is called with a KafkaAccess resource that references a tls listener, then the data returned includes the " +
+            "CA certificate")
+    void testSecretDataWithTls() {
+        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", cert);
+        final Secret certSecret = ResourceProvider.getStrimziSecret(KafkaResources.clusterCaCertificateSecretName(KAFKA_NAME), KAFKA_NAMESPACE, KAFKA_NAME);
+        certSecret.setData(certSecretData);
+        final Kafka kafka = ResourceProvider.getKafka(
+                KAFKA_NAME,
+                KAFKA_NAMESPACE,
+                List.of(ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true)),
+                List.of(ResourceProvider.getListenerStatus(LISTENER_1, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092))
+        );
+        final Context<KafkaAccess> mockContext = mock(Context.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
+
+        final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
+        final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference);
+
+        final EventSourceRetriever<KafkaAccess> mockEventSourceRetriever = mock(EventSourceRetriever.class);
+        final InformerEventSource<Secret, KafkaAccess> mockInformerEventSource = mock(InformerEventSource.class);
+        when(mockContext.eventSourceRetriever()).thenReturn(mockEventSourceRetriever);
+        when(mockEventSourceRetriever.getResourceEventSourceFor(Secret.class, KafkaAccessReconciler.STRIMZI_SECRET_EVENT_SOURCE)).thenReturn(mockInformerEventSource);
+        when(mockInformerEventSource.get(any(ResourceID.class))).thenReturn(Optional.of(certSecret));
+
+        Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
+        final Map<String, String> expectedDataEntries = new HashMap<>();
+        expectedDataEntries.put("type", encodeToString("kafka"));
+        expectedDataEntries.put("provider", encodeToString("strimzi"));
+        expectedDataEntries.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9092)));
+        expectedDataEntries.put("ssl.truststore.crt", cert);
         assertThat(data).containsAllEntriesOf(expectedDataEntries);
     }
 
@@ -88,18 +125,26 @@ public class SecretDependentResourceTest {
                 List.of(ResourceProvider.getListener(LISTENER_2, KafkaListenerType.INTERNAL, false, new KafkaListenerAuthenticationScramSha512())),
                 List.of(ResourceProvider.getListenerStatus(LISTENER_2, BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
         );
+        final Context<KafkaAccess> mockContext = mock(Context.class);
+        when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.of(kafka));
 
-        final KafkaUser kafkaUser = ResourceProvider.getKafkaUser(KAFKA_NAME, KAFKA_NAMESPACE, new KafkaUserScramSha512ClientAuthentication());
+        final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(KAFKA_NAME, KAFKA_NAMESPACE, KAFKA_USER_SECRET_NAME, "user", new KafkaUserScramSha512ClientAuthentication());
+        when(mockContext.getSecondaryResource(KafkaUser.class)).thenReturn(Optional.of(kafkaUser));
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReferenceWithListener(KAFKA_NAME, LISTENER_2, KAFKA_NAMESPACE);
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
 
-        Map<String, String> data = new SecretDependentResource().secretDataWithUser(kafkaAccess.getSpec(), kafka, kafkaUser, new KafkaUserData(kafkaUser));
-        final Base64.Encoder encoder = Base64.getEncoder();
+        final EventSourceRetriever<KafkaAccess> mockEventSourceRetriever = mock(EventSourceRetriever.class);
+        final InformerEventSource<Secret, KafkaAccess> mockInformerEventSource = mock(InformerEventSource.class);
+        when(mockContext.eventSourceRetriever()).thenReturn(mockEventSourceRetriever);
+        when(mockEventSourceRetriever.getResourceEventSourceFor(Secret.class, KafkaAccessReconciler.KAFKA_USER_SECRET_EVENT_SOURCE)).thenReturn(mockInformerEventSource);
+        when(mockInformerEventSource.get(any(ResourceID.class))).thenReturn(Optional.of(ResourceProvider.getStrimziUserSecret(KAFKA_USER_SECRET_NAME, KAFKA_NAMESPACE, KAFKA_NAME)));
+
+        Map<String, String> data = new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext);
         assertThat(data).containsEntry(
                 CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
-                encoder.encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093).getBytes(StandardCharsets.UTF_8))
+                encodeToString(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
         );
     }
 

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
@@ -60,16 +60,21 @@ public class KafkaListenerTest {
 
 
     @Test
-    @DisplayName("When Kafka listener with TLS enables is created, then the connection data is correct and the security protocol is SSL")
+    @DisplayName("When Kafka listener with TLS enabled is created, then the connection data is correct and the security protocol is SSL")
     void testTLSKafkaListener() {
+        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", cert);
         final GenericKafkaListener genericKafkaListener = ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true);
-        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092);
+        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092)
+                .withCaCertSecret(certSecretData);
 
         final Map<String, String> secretData = listener.getConnectionSecretData();
 
         final Map<String, String> expectedData = new HashMap<>();
         bootstrapServerKeys().forEach(key -> expectedData.put(key, encodeToString(BOOTSTRAP_SERVER_9092)));
         securityProtocolKeys().forEach(key -> expectedData.put(key, encodeToString(SecurityProtocol.SSL.name)));
+        expectedData.put("ssl.truststore.crt", cert);
         assertThat(secretData).containsAllEntriesOf(expectedData);
     }
 
@@ -90,14 +95,19 @@ public class KafkaListenerTest {
     @Test
     @DisplayName("When a Kafka listener with SASL auth and TLS enabled is created, then the connection data is correct and has security protocol SASL_SSL")
     void testKafkaListenerWithSaslAuthAndTls() {
+        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", cert);
         final GenericKafkaListener genericKafkaListener = ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true, new KafkaListenerAuthenticationScramSha512());
-        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092);
+        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092)
+                .withCaCertSecret(certSecretData);
 
         final Map<String, String> secretData = listener.getConnectionSecretData();
 
         final Map<String, String> expectedData = new HashMap<>();
         bootstrapServerKeys().forEach(key -> expectedData.put(key, encodeToString(BOOTSTRAP_SERVER_9092)));
         securityProtocolKeys().forEach(key -> expectedData.put(key, encodeToString(SecurityProtocol.SASL_SSL.name)));
+        expectedData.put("ssl.truststore.crt", cert);
         assertThat(secretData).containsAllEntriesOf(expectedData);
     }
 

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaParserTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaParserTest.java
@@ -49,7 +49,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec);
+        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec, null);
         assertThat(listener.getName()).isEqualTo(LISTENER_1);
         assertThat(listener.getType()).isEqualTo(KafkaListenerType.INTERNAL);
         assertThat(listener.isTls()).isFalse();
@@ -75,7 +75,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec);
+        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec, null);
         assertThat(listener.getName()).isEqualTo(LISTENER_1);
         assertThat(listener.getType()).isEqualTo(KafkaListenerType.INTERNAL);
         assertThat(listener.isTls()).isTrue();
@@ -103,7 +103,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec);
+        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec, null);
         assertThat(listener.getName()).isEqualTo("b");
         assertThat(listener.getType()).isEqualTo(KafkaListenerType.INTERNAL);
         assertThat(listener.isTls()).isFalse();
@@ -129,7 +129,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec);
+        final KafkaListener listener = KafkaParser.getKafkaListener(kafka, spec, null);
         assertThat(listener.getName()).isEqualTo("a");
         assertThat(listener.getType()).isEqualTo(KafkaListenerType.ROUTE);
         assertThat(listener.isTls()).isTrue();
@@ -155,7 +155,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class, () -> KafkaParser.getKafkaListener(kafka, spec));
+        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class, () -> KafkaParser.getKafkaListener(kafka, spec, null));
         assertThat(exception.getMessage()).isEqualTo(String.format("The specified listener %s is missing from the Kafka resource.", LISTENER_1));
     }
 
@@ -177,7 +177,7 @@ public class KafkaParserTest {
                 )
         );
 
-        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class, () -> KafkaParser.getKafkaListener(kafka, spec));
+        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class, () -> KafkaParser.getKafkaListener(kafka, spec, null));
         assertThat(exception.getMessage()).isEqualTo(String.format("The bootstrap server address for the listener %s is missing from the Kafka resource status.", LISTENER_1));
     }
 

--- a/src/test/java/io/strimzi/kafka/access/internal/KafkaUserDataTest.java
+++ b/src/test/java/io/strimzi/kafka/access/internal/KafkaUserDataTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.kafka.access.Base64Encoder.encodeToString;
+import static io.strimzi.kafka.access.Base64Encoder.encodeUtf8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class KafkaUserDataTest {
@@ -28,8 +28,8 @@ public class KafkaUserDataTest {
     @Test
     @DisplayName("When a ScramSha512 KafkaUserData is created with a secret, then the connection data contains the SASL properties")
     void testKafkaUserDataScramSha512Secret() {
-        final String password = encodeToString("password");
-        final String saslJaasConfig = encodeToString("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user-scram\" password=\"password\";");
+        final String password = encodeUtf8("password");
+        final String saslJaasConfig = encodeUtf8("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user-scram\" password=\"password\";");
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(SECRET_NAME, USERNAME, new KafkaUserScramSha512ClientAuthentication());
 
         final Map<String, String> kafkaUserSecretData = new HashMap<>();
@@ -38,19 +38,19 @@ public class KafkaUserDataTest {
         final Secret kafkaUserSecret = new SecretBuilder().withData(kafkaUserSecretData).build();
 
         final Map<String, String> secretData = new KafkaUserData(kafkaUser).withSecret(kafkaUserSecret).getConnectionSecretData();
-        assertThat(secretData.get("username")).isEqualTo(encodeToString(USERNAME));
-        assertThat(secretData.get("user")).isEqualTo(encodeToString(USERNAME));
+        assertThat(secretData.get("username")).isEqualTo(encodeUtf8(USERNAME));
+        assertThat(secretData.get("user")).isEqualTo(encodeUtf8(USERNAME));
         assertThat(secretData.get("password")).isEqualTo(password);
         assertThat(secretData.get(SaslConfigs.SASL_JAAS_CONFIG)).isEqualTo(saslJaasConfig);
-        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeToString("SCRAM-SHA-512"));
-        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeToString("SCRAM-SHA-512"));
+        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
+        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
     }
 
     @Test
     @DisplayName("When a ScramSha512 KafkaUserData is created with a secret and the status is missing, then the connection data contains the SASL properties without the username")
     void testKafkaUserDataScramSha512MissingStatus() {
-        final String password = encodeToString("password");
-        final String saslJaasConfig = encodeToString("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user-scram\" password=\"password\";");
+        final String password = encodeUtf8("password");
+        final String saslJaasConfig = encodeUtf8("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"my-user-scram\" password=\"password\";");
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUser("test", "test", new KafkaUserScramSha512ClientAuthentication());
 
         final Map<String, String> kafkaUserSecretData = new HashMap<>();
@@ -63,8 +63,8 @@ public class KafkaUserDataTest {
         assertThat(secretData.get("user")).isNull();
         assertThat(secretData.get("password")).isEqualTo(password);
         assertThat(secretData.get(SaslConfigs.SASL_JAAS_CONFIG)).isEqualTo(saslJaasConfig);
-        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeToString("SCRAM-SHA-512"));
-        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeToString("SCRAM-SHA-512"));
+        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
+        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
     }
 
     @Test
@@ -73,19 +73,19 @@ public class KafkaUserDataTest {
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(SECRET_NAME, USERNAME, new KafkaUserScramSha512ClientAuthentication());
 
         final Map<String, String> secretData = new KafkaUserData(kafkaUser).getConnectionSecretData();
-        assertThat(secretData.get("username")).isEqualTo(encodeToString(USERNAME));
-        assertThat(secretData.get("user")).isEqualTo(encodeToString(USERNAME));
+        assertThat(secretData.get("username")).isEqualTo(encodeUtf8(USERNAME));
+        assertThat(secretData.get("user")).isEqualTo(encodeUtf8(USERNAME));
         assertThat(secretData.get("password")).isNull();
         assertThat(secretData.get(SaslConfigs.SASL_JAAS_CONFIG)).isNull();
-        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeToString("SCRAM-SHA-512"));
-        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeToString("SCRAM-SHA-512"));
+        assertThat(secretData.get(SaslConfigs.SASL_MECHANISM)).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
+        assertThat(secretData.get("saslMechanism")).isEqualTo(encodeUtf8("SCRAM-SHA-512"));
     }
 
     @Test
     @DisplayName("When a tls KafkaUserData is created with a secret, then the connection data contains the correct certificate properties")
     void testKafkaUserDataTlsSecret() {
-        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
-        final String key = encodeToString("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
+        final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String key = encodeUtf8("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(SECRET_NAME, USERNAME, new KafkaUserTlsClientAuthentication());
 
         final Map<String, String> kafkaUserSecretData = new HashMap<>();
@@ -109,8 +109,8 @@ public class KafkaUserDataTest {
     @Test
     @DisplayName("When a tls external KafkaUserData is created with a secret, then the connection data contains the correct certificate properties")
     void testKafkaUserDataTlsExternalSecret() {
-        final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
-        final String key = encodeToString("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
+        final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
+        final String key = encodeUtf8("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(SECRET_NAME, USERNAME, new KafkaUserTlsExternalClientAuthentication());
 
         final Map<String, String> kafkaUserSecretData = new HashMap<>();


### PR DESCRIPTION
* Adds both truststore and keystore certificate files to the KafkaAccess secret. Only adds the pem files based on discussions under issue #33. 
* Separates out base64 encoding logic in test classes into separate static method.
* Updates the Strimzi secret event source to be a named source so it can be more easily accessed when fetching the truststore certificate.