### PR TITLE
feat: Add Ready status condition to KafkaAccess resource

### DIFF
--- a/packaging/install/040-Crd-kafkaaccess.yaml
+++ b/packaging/install/040-Crd-kafkaaccess.yaml
@@ -57,6 +57,25 @@ spec:
                     name:
                       type: string
                   type: object
+                conditions:
+                  items:
+                    properties:
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      type:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      additionalProperties:
+                        additionalProperties:
+                          type: object
+                        type: object
+                    type: object
+                  type: array
                 observedGeneration:
                   type: integer
               type: object

--- a/src/main/java/io/strimzi/kafka/access/internal/MissingKubernetesResourceException.java
+++ b/src/main/java/io/strimzi/kafka/access/internal/MissingKubernetesResourceException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.access.internal;
+
+/**
+ * The class for exception when Kuberentes resources are missing
+ */
+public class MissingKubernetesResourceException extends RuntimeException {
+    /**
+     * Default constructor
+     */
+    public MissingKubernetesResourceException() {}
+
+    /**
+     * Constructor
+     *
+     * @param message The exception message
+     */
+    public MissingKubernetesResourceException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message The exception message
+     * @param cause The exception cause
+     */
+    public MissingKubernetesResourceException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param cause The exception cause
+     */
+    public MissingKubernetesResourceException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/io/strimzi/kafka/access/model/KafkaAccessStatus.java
+++ b/src/main/java/io/strimzi/kafka/access/model/KafkaAccessStatus.java
@@ -5,6 +5,14 @@
 package io.strimzi.kafka.access.model;
 
 import io.javaoperatorsdk.operator.api.ObservedGenerationAwareStatus;
+import io.strimzi.api.kafka.model.status.Condition;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * The status model of the KafkaAccess resource
@@ -12,6 +20,7 @@ import io.javaoperatorsdk.operator.api.ObservedGenerationAwareStatus;
 public class KafkaAccessStatus extends ObservedGenerationAwareStatus {
 
     private BindingStatus binding;
+    private List<Condition> conditions = new ArrayList<>();
 
     /**
      * Gets the BindingStatus instance
@@ -29,6 +38,43 @@ public class KafkaAccessStatus extends ObservedGenerationAwareStatus {
      */
     public void setBinding(final BindingStatus bindingStatus) {
         this.binding = bindingStatus;
+    }
+
+    /**
+     * Gets the status conditions
+     *
+     * @return The status conditions
+     */
+    public List<Condition> getConditions() {
+        return conditions;
+    }
+
+    /**
+     * Replaces the Ready condition in the status
+     *
+     * @param ready Whether the resource is ready
+     */
+    public void setReadyCondition(final boolean ready) {
+        setReadyCondition(ready, null, null);
+    }
+
+    /**
+     * Replaces the Ready condition in the status
+     *
+     * @param ready Whether the resource is ready
+     * @param message The message for the status condition
+     * @param reason The reason for the status condition
+     */
+    public void setReadyCondition(final boolean ready, final String message, final String reason) {
+        final Condition condition = new Condition();
+        condition.setType("Ready");
+        condition.setStatus(ready ? "True" : "False");
+        condition.setLastTransitionTime(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
+        Optional.ofNullable(message)
+                .ifPresent(condition::setMessage);
+        Optional.ofNullable(reason)
+                .ifPresent(condition::setReason);
+        this.conditions = List.of(condition);
     }
 
 }

--- a/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
+++ b/src/test/java/io/strimzi/kafka/access/SecretDependentResourceTest.java
@@ -15,7 +15,7 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.kafka.access.internal.CustomResourceParseException;
+import io.strimzi.kafka.access.internal.MissingKubernetesResourceException;
 import io.strimzi.kafka.access.model.KafkaAccess;
 import io.strimzi.kafka.access.model.KafkaReference;
 import io.strimzi.kafka.access.model.KafkaUserReference;
@@ -158,7 +158,7 @@ public class SecretDependentResourceTest {
         final Context<KafkaAccess> mockContext = mock(Context.class);
         when(mockContext.getSecondaryResource(Kafka.class)).thenReturn(Optional.empty());
 
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+        final MissingKubernetesResourceException exception = assertThrows(MissingKubernetesResourceException.class,
                 () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
         assertThat(exception).hasMessage(String.format("Kafka %s/%s missing", KAFKA_NAMESPACE, KAFKA_NAME));
     }
@@ -187,7 +187,7 @@ public class SecretDependentResourceTest {
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
 
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+        final MissingKubernetesResourceException exception = assertThrows(MissingKubernetesResourceException.class,
                 () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
         assertThat(exception).hasMessage(String.format("KafkaUser %s/%s missing", KAFKA_NAMESPACE, KAFKA_USER_NAME));
     }
@@ -218,13 +218,13 @@ public class SecretDependentResourceTest {
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
 
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+        final MissingKubernetesResourceException exception = assertThrows(MissingKubernetesResourceException.class,
                 () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
         assertThat(exception).hasMessage(String.format("Secret in KafkaUser status %s/%s missing", KAFKA_NAMESPACE, KAFKA_USER_NAME));
     }
 
     @Test
-    @DisplayName("When desired is called with a KafkaAccess resource and the referenced KafkaUser resource's Secret, " +
+    @DisplayName("When desired is called with a KafkaAccess resource and the referenced KafkaUser resource's Secret is missing, " +
             "then it throws an exception")
     void testDesiredMissingKafkaUserSecret() {
         final Kafka kafka = ResourceProvider.getKafka(
@@ -254,7 +254,7 @@ public class SecretDependentResourceTest {
         final KafkaUserReference kafkaUserReference = ResourceProvider.getKafkaUserReference(KAFKA_USER_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, kafkaUserReference);
 
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+        final MissingKubernetesResourceException exception = assertThrows(MissingKubernetesResourceException.class,
                 () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
         assertThat(exception).hasMessage(String.format("Secret %s for KafkaUser %s/%s missing", KAFKA_USER_SECRET_NAME, KAFKA_NAMESPACE, KAFKA_USER_NAME));
     }
@@ -288,7 +288,7 @@ public class SecretDependentResourceTest {
 
         final KafkaReference kafkaReference = ResourceProvider.getKafkaReference(KAFKA_NAME, KAFKA_NAMESPACE);
         final KafkaAccess kafkaAccess = ResourceProvider.getKafkaAccess(NAME, NAMESPACE, kafkaReference, userReference);
-        final CustomResourceParseException exception = assertThrows(CustomResourceParseException.class,
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
                 () -> new SecretDependentResource().desired(kafkaAccess.getSpec(), NAMESPACE, mockContext));
         assertThat(exception).hasMessage("User kind must be KafkaUser and apiGroup must be kafka.strimzi.io");
     }


### PR DESCRIPTION
Add "Ready" condition to the KafkaAccess resource. The Condition class used is the Strimzi one and this change enables users to see why their binding has not worked, rather than needing to read the operator logs.