### PR TITLE
Add Namespace to Helm charts

### DIFF
--- a/packaging/helm-charts/helm3/kafka-access-operator/templates/010-ServiceAccount.yaml
+++ b/packaging/helm-charts/helm3/kafka-access-operator/templates/010-ServiceAccount.yaml
@@ -5,3 +5,4 @@ metadata:
   name: strimzi-access-operator
   labels:
     app: strimzi-access-operator
+  namespace: {{ .Release.Namespace }}

--- a/packaging/helm-charts/helm3/kafka-access-operator/templates/030-ClusterRoleBinding.yaml
+++ b/packaging/helm-charts/helm3/kafka-access-operator/templates/030-ClusterRoleBinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-access-operator
-    namespace: strimzi-access-operator
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: strimzi-access-operator

--- a/packaging/helm-charts/helm3/kafka-access-operator/templates/050-Deployment.yaml
+++ b/packaging/helm-charts/helm3/kafka-access-operator/templates/050-Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: strimzi-access-operator
   labels:
     app: strimzi-access-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Currently, when we try to install Kafka Access Operator using Helm in different Namespace than `strimzi-access-operator` (which is hard-coded in the files), we are getting:

```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://172.30.0.1:443/apis/access.strimzi.io/v1alpha1/kafkaaccesses?resourceVersion=0. Message: kafkaaccesses.access.strimzi.io is forbidden: User "system:serviceaccount:main-namespace:strimzi-access-operator" cannot list resource "kafkaaccesses" in API group "access.strimzi.io" at the cluster scope. Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=access.strimzi.io, kind=kafkaaccesses, name=null, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=kafkaaccesses.access.strimzi.io is forbidden: User "system:serviceaccount:main-namespace:strimzi-access-operator" cannot list resource "kafkaaccesses" in API group "access.strimzi.io" at the cluster scope, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={}).
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:660)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:640)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:589)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:549)
        at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
        at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$10(StandardHttpClient.java:142)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
        at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
        at io.fabric8.kubernetes.client.utils.AsyncUtils.lambda$retryWithExponentialBackoff$3(AsyncUtils.java:90)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
        at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
        at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614)
        at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:844)
        at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
```

This PR adds the Namespace to the files where they are needed (and removes the hard-coded version).