### PR TITLE
Update various dependencies before the initial release

### DIFF
--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -34,15 +34,15 @@ jobs:
           echo "##vso[task.setvariable variable=docker_registry]$(kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'):80"
         displayName: "Set docker_registry to local registry in minikube"
         condition: eq(variables['docker_registry'], 'localhost:5000')
-      - task: Maven@3
+      - task: Maven@4
         inputs:
-          mavenPomFile: 'pom.xml'
+          mavenPOMFile: 'pom.xml'
           goals: 'install'
           options: '-B -Dmaven.javadoc.skip=true -DskipTests -am -pl systemtest'
         displayName: 'Build systemtest module'
-      - task: Maven@3
+      - task: Maven@4
         inputs:
-          mavenPomFile: 'systemtest/pom.xml'
+          mavenPOMFile: 'systemtest/pom.xml'
           publishJUnitResults: true
           testResultsFiles: '**/failsafe-reports/TEST-*.xml'
           goals: 'verify'
@@ -52,9 +52,9 @@ jobs:
           DOCKER_ORG: strimzi
           DOCKER_TAG: latest
         displayName: 'Run systemtests - $(arch) - Bundle installation'
-      - task: Maven@3
+      - task: Maven@4
         inputs:
-          mavenPomFile: 'systemtest/pom.xml'
+          mavenPOMFile: 'systemtest/pom.xml'
           publishJUnitResults: true
           testResultsFiles: '**/failsafe-reports/TEST-*.xml'
           goals: 'verify'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     # Setup OpenJDK
     - name: Setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'temurin'
@@ -47,7 +47,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -72,4 +72,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
 
-RUN microdnf update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
-    && microdnf clean all
+RUN microdnf update -y \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf clean all -y
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/jre-17

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,24 @@
             <organization>CN Group</organization>
             <organizationUrl>https://www.cngroup.dk</organizationUrl>
         </developer>
+        <developer>
+            <name>Paul Mellor</name>
+            <email>pmellor@redhat.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Lukáš Král</name>
+            <email>l.kral@outlook.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Maroš Orsák</name>
+            <email>maros.orsak159@gmail.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
     </developers>
 
     <properties>
@@ -97,13 +115,13 @@
 
         <!-- Runtime dependencies -->
         <javaoperatorsdk.version>4.4.2</javaoperatorsdk.version>
-        <fabric8.version>6.13.0</fabric8.version>
-        <strimzi.version>0.41.0</strimzi.version>
-        <kafka.clients.version>3.0.0</kafka.clients.version>
+        <fabric8.version>6.13.4</fabric8.version>
+        <strimzi.version>0.43.0</strimzi.version>
+        <kafka.clients.version>3.8.0</kafka.clients.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
-        <jetty.version>11.0.14</jetty.version>
+        <jetty.version>11.0.24</jetty.version>
         <jetty.jakarta-servlet-api.version>5.0.2</jetty.jakarta-servlet-api.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
This PR updates various dependencies before we do the initial release. It bumps Kafka, Fabric8 and Jetty. It also updates the base image to UBI9 that we now use in other projects as well.