### PR TITLE
Add additional printer columns to KafkaAccess

### DIFF
--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
@@ -18,8 +18,10 @@ import io.sundr.builder.annotations.Buildable;
 public class KafkaReference {
 
     @Required
+    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "Cluster")
     private String name;
     private String namespace;
+    @io.fabric8.crd.generator.annotation.PrinterColumn()
     private String listener;
 
     /**

--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
@@ -21,7 +21,7 @@ public class KafkaReference {
     @io.fabric8.crd.generator.annotation.PrinterColumn(name = "Cluster")
     private String name;
     private String namespace;
-    @io.fabric8.crd.generator.annotation.PrinterColumn()
+    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "Listener")
     private String listener;
 
     /**

--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
@@ -22,6 +22,7 @@ public class KafkaUserReference {
     @Required
     private String apiGroup;
     @Required
+    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "User")
     private String name;
     private String namespace;
 

--- a/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
     - additionalPrinterColumns:
         - jsonPath: .spec.kafka.listener
-          name: LISTENER
+          name: Listener
           priority: 0
           type: string
         - jsonPath: .spec.kafka.name

--- a/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
@@ -15,7 +15,20 @@ spec:
     singular: kafkaaccess
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .spec.kafka.listener
+          name: LISTENER
+          priority: 0
+          type: string
+        - jsonPath: .spec.kafka.name
+          name: Cluster
+          priority: 0
+          type: string
+        - jsonPath: .spec.user.name
+          name: User
+          priority: 0
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           properties:

--- a/packaging/install/040-Crd-kafkaaccess.yaml
+++ b/packaging/install/040-Crd-kafkaaccess.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
     - additionalPrinterColumns:
         - jsonPath: .spec.kafka.listener
-          name: LISTENER
+          name: Listener
           priority: 0
           type: string
         - jsonPath: .spec.kafka.name

--- a/packaging/install/040-Crd-kafkaaccess.yaml
+++ b/packaging/install/040-Crd-kafkaaccess.yaml
@@ -15,7 +15,20 @@ spec:
     singular: kafkaaccess
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .spec.kafka.listener
+          name: LISTENER
+          priority: 0
+          type: string
+        - jsonPath: .spec.kafka.name
+          name: Cluster
+          priority: 0
+          type: string
+        - jsonPath: .spec.user.name
+          name: User
+          priority: 0
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           properties:


### PR DESCRIPTION
This PR adds the following additional printer columns to KafkaAccess:
- listener
- cluster
- user

For example: 
```
NAME              LISTENER   CLUSTER      USER
my-kafka-access   tls        my-cluster   my-user
```

Partially addresses #53 