### PR TITLE
Integrate Helm Chart into the release tooling - Closes #58

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -47,6 +47,7 @@ stages:
           - template: 'templates/steps/prerequisites/install_java.yaml'
             parameters:
               JDK_VERSION: $(jdk_version)
+          - template: "templates/steps/prerequisites/install_helm.yaml"
           - bash: ".azure/scripts/release-artifacts.sh"
             env:
               BUILD_REASON: $(Build.Reason)
@@ -58,6 +59,8 @@ stages:
             artifact: ReleaseTarGzArchive
           - publish: $(System.DefaultWorkingDirectory)/strimzi-access-operator-${{ parameters.releaseVersion }}.zip
             artifact: ReleaseZipArchive
+          - publish: $(System.DefaultWorkingDirectory)/strimzi-access-operator-helm-3-chart-${{ parameters.releaseVersion }}.tgz
+            artifact: HelmChartArchive
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
@@ -89,3 +92,18 @@ stages:
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
           architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
+  # Publishes the Helm Chart as an OCI artifact to Quay.io
+  - stage: helm_as_oci_publish
+    displayName: Publish Helm Chart as OCI artifact
+    dependsOn:
+      - containers_publish
+    condition: and(in(dependencies.containers_publish.result, 'Succeeded', 'SucceededWithIssues'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    jobs:
+      - template: 'templates/jobs/push_helm_chart.yaml'
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''

--- a/.azure/scripts/setup-helm.sh
+++ b/.azure/scripts/setup-helm.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -x
+
+TEST_HELM3_VERSION=${TEST_HELM3_VERSION:-'v3.16.2'}
+
+function install_helm3 {
+    export HELM_INSTALL_DIR=/usr/bin
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+    # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured
+    sed -i 's#/usr/local/bin#/usr/bin#g' get_helm.sh
+    chmod 700 get_helm.sh
+
+    echo "Installing helm 3..."
+    sudo ./get_helm.sh --version "${TEST_HELM3_VERSION}"
+
+    echo "Verifying the installation of helm binary..."
+    # run a proper helm command instead of, for example, "which helm", to verify that we can call the binary
+    helm --help
+    helmCommandOutput=$?
+
+    if [ $helmCommandOutput != 0 ]; then
+        echo "helm binary hasn't been installed properly - exiting..."
+        exit 1
+    fi
+}
+
+install_helm3

--- a/.azure/templates/jobs/push_helm_chart.yaml
+++ b/.azure/templates/jobs/push_helm_chart.yaml
@@ -1,0 +1,38 @@
+jobs:
+  - job: 'push_helm_chart_oci'
+    displayName: 'Push Helm Chart as OCI artifact'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: 'Ubuntu-22.04'
+    # Pipeline steps
+    steps:
+      # Install Prerequisites
+      - template: "../steps/prerequisites/install_helm.yaml"
+
+      # Unpack the release artifacts
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: '${{ parameters.artifactSource }}'
+          artifact: HelmChartArchive
+          path: $(System.DefaultWorkingDirectory)/
+          project: '${{ parameters.artifactProject }}'
+          pipeline: '${{ parameters.artifactPipeline }}'
+          runVersion: '${{ parameters.artifactRunVersion }}'
+          runId: '${{ parameters.artifactRunId }}'
+
+      # Login Helm to the OCI Registry
+      - bash: "helm registry login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY"
+        displayName: "Login to OCI registry"
+        env:
+          DOCKER_USER: $(QUAY_HELM_USER)
+          DOCKER_PASS: $(QUAY_HELM_PASS)
+          DOCKER_REGISTRY: "quay.io"
+
+      # Push the Helm Chart to the OCI Registry
+      - bash: "helm push strimzi-access-operator-helm-3-chart-${{ parameters.releaseVersion }}.tgz oci://$DOCKER_REGISTRY/$DOCKER_ORG"
+        displayName: "Push Helm Chart OCI artifact"
+        env:
+          DOCKER_REGISTRY: "quay.io"
+          DOCKER_ORG: "strimzi-helm"

--- a/.azure/templates/steps/prerequisites/install_helm.yaml
+++ b/.azure/templates/steps/prerequisites/install_helm.yaml
@@ -1,0 +1,5 @@
+steps:
+  - bash: ".azure/scripts/setup-helm.sh"
+    displayName: "Install Helm"
+    env:
+      TEST_HELM3_VERSION: 'v3.16.2'

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ release_prepare:
 	rm -rf ./strimzi-access-operator-$(RELEASE_VERSION)
 	rm -f ./strimzi-access-operator-$(RELEASE_VERSION).tar.gz
 	rm -f ./strimzi-access-operator-$(RELEASE_VERSION).zip
+	rm -f ./strimzi-access-operator-helm-3-chart-$(RELEASE_VERSION).zip
 	mkdir ./strimzi-access-operator-$(RELEASE_VERSION)
 
 release_version:
@@ -24,13 +25,17 @@ release_version:
 	echo $(shell echo $(RELEASE_VERSION) | tr a-z A-Z) > release.version
 	echo "Changing Docker image tags in install to :$(RELEASE_VERSION)"
 	$(FIND) ./packaging/install -name '*.yaml' -type f -exec $(SED) -i '/image: "\?quay.io\/strimzi\/[a-zA-Z0-9_.-]\+:[a-zA-Z0-9_.-]\+"\?/s/:[a-zA-Z0-9_.-]\+/:$(RELEASE_VERSION)/g' {} \;
+	echo "Changing Docker image tags in Helm Chart to :$(RELEASE_VERSION)"
+	CHART_PATH=./packaging/helm-charts/helm3/strimzi-access-operator; \
+	$(SED) -i 's/\(tag: \).*/\1$(RELEASE_VERSION)/g' $$CHART_PATH/values.yaml; \
+	$(SED) -i 's/\(image.tag[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $$CHART_PATH/README.md
 
 release_maven:
 	echo "Update pom versions to $(RELEASE_VERSION)"
 	mvn $(MVN_ARGS) versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
 	mvn $(MVN_ARGS) versions:commit
 
-release_pkg:
+release_pkg: helm_pkg
 	$(CP) -r ./packaging/install ./
 	$(CP) -r ./packaging/install ./strimzi-access-operator-$(RELEASE_VERSION)/
 	$(CP) -r ./packaging/examples ./
@@ -38,16 +43,22 @@ release_pkg:
 	tar -z -cf ./strimzi-access-operator-$(RELEASE_VERSION).tar.gz strimzi-access-operator-$(RELEASE_VERSION)/
 	zip -r ./strimzi-access-operator-$(RELEASE_VERSION).zip strimzi-access-operator-$(RELEASE_VERSION)/
 	rm -rf ./strimzi-access-operator-$(RELEASE_VERSION)
+	rm -rfv ./examples
+	$(CP) -rv ./packaging/examples ./examples
+	rm -rfv ./install
+	mkdir ./install
 	$(FIND) ./packaging/install/ -mindepth 1 -maxdepth 1 ! -name Makefile -type f,d -exec $(CP) -rv {} ./install/ \;
+	rm -rfv ./helm-charts/helm3/strimzi-access-operator
+	mkdir -p ./helm-charts/helm3/
+	$(CP) -rv ./packaging/helm-charts/helm3/strimzi-access-operator ./helm-charts/helm3/strimzi-access-operator
 
-.PHONY: all
-all: java_package docker_build docker_push crd_install helm_install
-
-.PHONY: build
-build: java_verify crd_install docker_build
-
-.PHONY: clean
-clean: java_clean
+helm_pkg:
+	# Copying unarchived Helm Chart to release directory
+	mkdir -p strimzi-access-operator-$(RELEASE_VERSION)/helm3-chart/
+	helm package --version $(RELEASE_VERSION) --app-version $(RELEASE_VERSION) --destination ./ ./packaging/helm-charts/helm3/strimzi-access-operator/
+	$(CP) strimzi-access-operator-$(RELEASE_VERSION).tgz strimzi-access-operator-helm-3-chart-$(RELEASE_VERSION).tgz
+	rm -rf strimzi-access-operator-$(RELEASE_VERSION)/helm3-chart/
+	rm strimzi-access-operator-$(RELEASE_VERSION).tgz
 
 .PHONY: crd_install
 crd_install:
@@ -57,16 +68,21 @@ crd_install:
 	yq eval -i '.metadata.labels."servicebinding.io/provisioned-service"="true"' ./packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
 
 .PHONY: helm_install
-helm_install:
-	mkdir -p ./target/helm
-	helm template --namespace strimzi-access-operator --output-dir ./target/helm ./packaging/helm-charts/helm3/strimzi-access-operator/
-	$(FIND) ./target/helm/strimzi-access-operator/templates/ -type f -name '*.yaml' -exec $(SED) -i '/^---/d' {} \;
-	$(FIND) ./target/helm/strimzi-access-operator/templates/ -type f -name '*.yaml' -exec $(SED) -i '/^# Source: /d' {} \;
-	$(CP) -v ./target/helm/strimzi-access-operator/templates/*.yaml ./packaging/install/
-	rm -rf ./target/helm
+helm_install: packaging/helm-charts/helm3
+	$(MAKE) -C packaging/helm-charts/helm3 $(MAKECMDGOALS)
 
 .PHONY: next_version
 next_version:
 	echo $(shell echo $(NEXT_VERSION) | tr a-z A-Z) > release.version
 	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)
 	mvn versions:commit
+
+
+.PHONY: all
+all: java_package docker_build docker_push crd_install helm_install
+
+.PHONY: build
+build: java_verify crd_install docker_build
+
+.PHONY: clean
+clean: java_clean

--- a/packaging/helm-charts/helm3/Makefile
+++ b/packaging/helm-charts/helm3/Makefile
@@ -1,0 +1,48 @@
+PROJECT_NAME=helm-charts
+
+include ../../../Makefile.os
+
+RELEASE_VERSION ?= latest
+CHART_NAME=strimzi-access-operator
+CHART_PATH ?= ../helm3/strimzi-access-operator
+CHART_RENDERED_TEMPLATES_TMP=../../../target/charts
+CHART_RENDERED_TEMPLATES_INSTALL=../../install
+HELM_CLI=helm
+
+helm_clean:
+	rm -rfv $(CHART_RENDERED_TEMPLATES_TMP)
+	rm -rf strimzi-$(RELEASE_VERSION)/charts/
+	rm -f $(CHART_NAME)-*.tgz
+
+helm_lint:
+	# Linting Helm Chart
+	$(HELM_CLI) lint --debug $(CHART_PATH)
+
+helm_install:
+	# Copying rendered template files to: $(CHART_RENDERED_TEMPLATES_INSTALL)
+	mkdir -p $(CHART_RENDERED_TEMPLATES_TMP)
+	helm template --namespace strimzi-access-operator --output-dir $(CHART_RENDERED_TEMPLATES_TMP) $(CHART_PATH)
+	$(FIND) $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec $(SED) -i '/^---/d' {} \;
+	$(FIND) $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' -exec $(SED) -i '/^# Source: /d' {} \;
+	$(FIND) $(CHART_RENDERED_TEMPLATES_TMP) -type f -name '*.yaml' \
+	    | xargs -IFILE $(CP) FILE $(CHART_RENDERED_TEMPLATES_INSTALL)
+	rm -rf $(CHART_RENDERED_TEMPLATES_TMP)
+
+helm_pkg: helm_clean helm_lint helm_install
+	# Copying unarchived Helm Chart to release directory
+	mkdir -p strimzi-$(RELEASE_VERSION)/charts/
+	$(CP) -r $(CHART_PATH) strimzi-$(RELEASE_VERSION)/charts/$(CHART_NAME)
+	# Packaging helm chart with semantic version: $(RELEASE_VERSION)
+	$(HELM_CLI) package --version $(RELEASE_VERSION) --app-version $(RELEASE_VERSION) --destination ./ $(CHART_PATH)
+	rm -rf strimzi-$(RELEASE_VERSION)
+
+java_build: helm_install
+java_install: java_build
+docker_build: helm_install
+docker_tag:
+docker_push:
+
+all: docker_build
+clean: helm_clean
+
+.PHONY: build clean release spotbugs

--- a/packaging/helm-charts/helm3/strimzi-access-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/README.md
@@ -1,0 +1,151 @@
+# Strimzi Access Operator
+
+Strimzi Access Operator provides a Kubernetes operator to help applications bind to an [Apache Kafka®](https://kafka.apache.org) cluster that is managed by the [Strimzi](https://strimzi.io) cluster operator.
+
+The operator creates a single Kubernetes `Secret` resource containing all the connection details for the Kafka cluster.
+The removes the need for applications to query multiple Kubernetes resources to get connection information.
+The `Secret` follows the conventions laid out in the [Service Binding Specification for Kubernetes v1.0.0](https://servicebinding.io/spec/core/1.0.0/).
+
+The operator is built using the [Java Operator SDK](https://github.com/java-operator-sdk/java-operator-sdk).
+
+## Running the Access Operator
+
+The Access Operator is still in early stages of development so to run it you need to build it from source.
+The [dev guide](https://github.com/strimzi/kafka-access-operator/blob/main/development-docs/DEV_GUIDE.md) describes how to build and run the Access Operator.
+
+To start the operator you need the Strimzi `Kafka` and `KafkaUser` custom resource definitions installed in your Kubernetes cluster.
+You can get these from the Strimzi [GitHub repository](https://github.com/strimzi/strimzi-kafka-operator/tree/main/packaging/install/cluster-operator),
+or use the [Strimzi quickstart guide](https://strimzi.io/quickstarts/) to also deploy the Strimzi cluster operator and a Kafka instance at the same time.
+
+## Using the Access Operator
+
+To make use of the Access Operator, create a `KafkaAccess` custom resource (CR).
+You must specify the name of the `Kafka` CR you want to connect to.
+You can optionally also specify the name of the listener in the `Kafka` CR and a `KafkaUser`.
+See the [examples folder](https://github.com/strimzi/kafka-access-operator/tree/main/packaging/examples) for some valid `KafkaAccess` specifications.
+
+If you do not specify which listener you want to connect to, the operator uses the following rules to choose a listener:
+1. If there is only one listener configured in the `Kafka` CR, that listener is chosen.
+2. If there are multiple listeners listed in the `Kafka` CR, the operator filters the list by comparing the `tls` and `authentication` properties in the `Kafka` and `KafkaUser` CRs to select a listener with the appropriate security.
+3. If there are multiple listeners with appropriate security, the operator chooses the one that is of type `internal`.
+4. If there are multiple internal listeners with appropriate security, the operator sorts the listeners alphabetically by name, and chooses the first one.
+
+Once the Access Operator has created the binding `Secret`, it updates the `KafkaAccess` custom resource to put the name of the secret in the status, for example:
+
+```yaml
+...
+status:
+  binding:
+    name: kafka-binding
+```
+
+The `Secret` created by the Access Operator has the following structure:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kafka-binding
+type: servicebinding.io/kafka
+data:
+    type: kafka
+    provider: strimzi
+
+    bootstrap.servers: # comma separated list of host:port for Kafka
+    bootstrap-servers: # comma separated list of host:port for Kafka
+    bootstrapServers: # comma separated list of host:port for Kafka
+
+    security.protocol: # one of PLAINTEXT, SASL_PLAINTEXT, SASL_SSL or SSL
+    securityProtocol: # one of PLAINTEXT, SASL_PLAINTEXT, SASL_SSL or SSL
+
+    # Provided if TLS enabled:
+    ssl.truststore.crt: #  Strimzi cluster CA certificate
+
+    # Provided if selected user is SCRAM auth:
+    username: # SCRAM username
+    password: # SCRAM password
+    sasl.jaas.config: # sasl jaas config string for use by Java applications
+    sasl.mechanism: SCRAM-SHA-512
+    saslMechanism: SCRAM-SHA-512
+
+    # Provided if selected user is mTLS:
+    ssl.keystore.crt: # certificate for the consuming client signed by the clients' CA
+    ssl.keystore.key: # private key for the consuming client
+```
+
+Developers can make this `Secret` available to their applications themselves, or use an operator that implements the [Service Binding specification](https://servicebinding.io/spec/core/1.0.0/) to do it.
+
+## Getting help
+
+If you encounter any issues while using the Access Operator, you can get help through the following methods:
+
+- [Strimzi Users mailing list](https://lists.cncf.io/g/cncf-strimzi-users/topics)
+- [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
+- [GitHub Discussions](https://github.com/orgs/strimzi/discussions)
+
+## Contributing
+
+You can contribute by:
+- Raising any issues you find using the Access Operator
+- Fixing issues by opening Pull Requests
+- Improving documentation
+- Talking about the Strimzi Access Operator
+
+All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/kafka-access-operator/issues).
+
+The [dev guide](https://github.com/strimzi/kafka-access-operator/blob/main/development-docs/DEV_GUIDE.md) describes how to build the operator and how to test your changes before submitting a patch or opening a PR.
+
+If you want to get in touch with us first before contributing, you can use:
+
+- [Strimzi Dev mailing list](https://lists.cncf.io/g/cncf-strimzi-dev/topics)
+- [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
+
+Learn more on how you can contribute on our [Join Us](https://strimzi.io/join-us/) page.
+
+## License
+
+Strimzi Access Operator is licensed under the [Apache License](./LICENSE), Version 2.0
+
+## Installing the Chart
+
+To install the chart with the release name `my-strimzi-drain-cleaner`:
+
+```bash
+$ helm install my-strimzi-access-operator oci://quay.io/strimzi-helm/strimzi-access-operator
+```
+
+The command deploys the Strimzi Access Operator on the Kubernetes cluster with the default configuration.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-strimzi-access-operator` deployment:
+
+```bash
+$ helm delete my-strimzi-access-operator
+```
+
+The command removes all the Kubernetes components associated with the Strimzi Access Operator utility and deletes the release.
+
+## Configuration
+
+The following table lists some available configurable parameters of the Strimzi chart and their default values.
+For a full list of supported options, check the [`values.yaml` file](./values.yaml).
+
+| Parameter                            | Description                                               | Default  |
+|--------------------------------------|-----------------------------------------------------------|----------|
+| `image.tag`                          | Override default Drain Cleaner image tag                  | `latest` |
+| `image.imagePullPolicy`              | Image pull policy for all pods deployed by Drain Cleaner  | `nil`    |
+| `resources.limits.cpu`               | Configures the CPU limit for the Access Operator Pod      | `256Mi`  |
+| `resources.limits.memory`            | Configures the memory limit for the Access Operator Pod   | `500m`   |
+| `resources.requests.cpu`             | Configures the CPU request for the Access Operator Pod    | `256Mi`  |
+| `resources.requests.memory`          | Configures the memory request for the Access Operator Pod | `100m`   |
+| `livenessProbe.initialDelaySeconds`  | Liveness probe initial delay (in seconds)                 | `10`     |
+| `livenessProbe.periodSeconds`        | Liveness probe period (in seconds)                        | `30`     |
+| `readinessProbe.initialDelaySeconds` | Readiness probe initial delay (in seconds)                | `10`     |
+| `readinessProbe.periodSeconds`       | Readiness probe period (in seconds)                       | `30`     |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install my-strimzi-access-operator --set replicaCount=2 oci://quay.io/strimzi-helm/strimzi-access-operator
+```


### PR DESCRIPTION
This PR tries to integrate the Helm Chart into the release tooling and pipelines. It also adds a README file to the Helm Chart that we were missing. Its content is based on the main README file from this repo.

This should resolve #58. I tested this locally as much as possible, but the release pipelines are used only as part of the release, so this part will be really tested only in the next release.