### PR TITLE
Remove unnecessary Make goals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ crd_install:
 
 .PHONY: helm_install
 helm_install: packaging/helm-charts/helm3
-	$(MAKE) -C packaging/helm-charts/helm3 $(MAKECMDGOALS)
+	$(MAKE) -C packaging/helm-charts/helm3 helm_install
 
 .PHONY: next_version
 next_version:

--- a/packaging/helm-charts/helm3/Makefile
+++ b/packaging/helm-charts/helm3/Makefile
@@ -36,13 +36,7 @@ helm_pkg: helm_clean helm_lint helm_install
 	$(HELM_CLI) package --version $(RELEASE_VERSION) --app-version $(RELEASE_VERSION) --destination ./ $(CHART_PATH)
 	rm -rf strimzi-$(RELEASE_VERSION)
 
-java_build: helm_install
-java_install: java_build
-docker_build: helm_install
-docker_tag:
-docker_push:
-
-all: docker_build
+all: helm_install
 clean: helm_clean
 
-.PHONY: build clean release spotbugs
+.PHONY: all clean


### PR DESCRIPTION
Since we do not run goals against a set of
directories there is no need to have additional
goals specified in the Helm directory Makefile.

There is a matching PR for this in [drain-cleaner](https://github.com/strimzi/drain-cleaner/pull/136)