### PR TITLE
Add publishing of the API artifact to Maven repositories

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -59,3 +59,17 @@ stages:
           artifactRunVersion: ''
           artifactRunId: ''
           architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
+  - stage: java_deploy
+    displayName: Deploy Java
+    dependsOn:
+      - run_systemtests
+    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
+    jobs:
+      - template: 'templates/jobs/deploy_java.yaml'
+        parameters:
+          dockerTag: 'latest'
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''

--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Build reason: ${BUILD_REASON}"
+echo "Source branch: ${BRANCH}"
+
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
+
+# Run the cleanup on failure / exit
+trap cleanup EXIT
+
+export GPG_TTY=$(tty)
+echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
+gpg --batch --import signing.gpg
+
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,api -P ossrh deploy
+
+cleanup

--- a/.azure/scripts/settings.xml
+++ b/.azure/scripts/settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -1,0 +1,41 @@
+jobs:
+  - job: 'deploy_java'
+    displayName: 'Deploy Java'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Strategy for the job
+    strategy:
+      matrix:
+        'java-17':
+          image: 'Ubuntu-22.04'
+          jdk_version: '17'
+    # Base system
+    pool:
+      vmImage: $(image)
+    # Pipeline steps
+    steps:
+      - template: "../steps/maven_cache.yaml"
+      - template: '../steps/prerequisites/install_java.yaml'
+        parameters:
+          JDK_VERSION: $(jdk_version)
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: '${{ parameters.artifactSource }}'
+          artifact: Binary
+          path: $(System.DefaultWorkingDirectory)/
+          project: '${{ parameters.artifactProject }}'
+          pipeline: '${{ parameters.artifactPipeline }}'
+          runVersion: '${{ parameters.artifactRunVersion }}'
+          runId: '${{ parameters.artifactRunId }}'
+      - bash: tar -xvf target.tar
+        displayName: "Untar the target directory"
+      - bash: "./.azure/scripts/push-to-nexus.sh"
+        env:
+          MVN_ARGS: "-e -V -B"
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+          GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
+          NEXUS_USERNAME: $(NEXUS_USERNAME)
+          NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+        displayName: "Deploy Java artifacts"

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.strimzi.kafka.access</groupId>
+        <groupId>io.strimzi.access-operator</groupId>
         <artifactId>kafka-access-operator</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.strimzi.kafka.access</groupId>
+        <groupId>io.strimzi.access-operator</groupId>
         <artifactId>kafka-access-operator</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
@@ -107,7 +107,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.strimzi.kafka.access</groupId>
+            <groupId>io.strimzi.access-operator</groupId>
             <artifactId>api</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.strimzi.kafka.access</groupId>
+    <groupId>io.strimzi.access-operator</groupId>
     <artifactId>kafka-access-operator</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -118,6 +118,8 @@
         <maven.shade.version>3.1.0</maven.shade.version>
         <maven.dependency.version>3.3.0</maven.dependency.version>
         <maven.assembly.version>3.3.0</maven.assembly.version>
+        <maven.gpg.version>3.0.1</maven.gpg.version>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
         <!-- Runtime dependencies -->
         <javaoperatorsdk.version>4.4.2</javaoperatorsdk.version>
@@ -283,7 +285,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.strimzi.kafka.access</groupId>
+                <groupId>io.strimzi.access-operator</groupId>
                 <artifactId>api</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -434,4 +436,54 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <!--suppress UnresolvedMavenProperty -->
+                <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+                <!--suppress UnresolvedMavenProperty -->
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven.gpg.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--batch</arg>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${sonatype.nexus.staging}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.strimzi.kafka.access</groupId>
+        <groupId>io.strimzi.access-operator</groupId>
         <artifactId>kafka-access-operator</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
@@ -61,7 +61,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.strimzi.kafka.access</groupId>
+            <groupId>io.strimzi.access-operator</groupId>
             <artifactId>api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This Pr adds publishing of the `api` module to Maven repositories (Sonatype Snapshots for snapshots and Maven CEntral for releases). It also renamed the group used by the artifacts to make it _a bit nicer_.