### PR TITLE
Added PKCS12 certificate file and password to KafkaAccess secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ data:
     # Provided if selected user is mTLS:
     ssl.keystore.crt: # certificate for the consuming client signed by the clients' CA
     ssl.keystore.key: # private key for the consuming client
+    ssl.keystore.p12: # certificate and private key as PKCS12 keystore for the consuming client
+    ssl.keystore.password: # keystore password for the PKCS12 keystore for the consuming client
 ```
 
 Developers can make this `Secret` available to their applications themselves, or use an operator that implements the [Service Binding specification](https://servicebinding.io/spec/core/1.0.0/) to do it.

--- a/helm-charts/helm3/strimzi-access-operator/README.md
+++ b/helm-charts/helm3/strimzi-access-operator/README.md
@@ -112,8 +112,6 @@ data:
     # Provided if selected user is mTLS:
     ssl.keystore.crt: # certificate for the consuming client signed by the clients' CA
     ssl.keystore.key: # private key for the consuming client
-    ssl.keystore.p12: # certificate and private key as PKCS12 keystore for the consuming client
-    ssl.keystore.password: # keystore password for the PKCS12 keystore for the consuming client
 ```
 
 Developers can make this `Secret` available to their applications themselves, or use an operator that implements the [Service Binding specification](https://servicebinding.io/spec/core/1.0.0/) to do it.

--- a/helm-charts/helm3/strimzi-access-operator/README.md
+++ b/helm-charts/helm3/strimzi-access-operator/README.md
@@ -112,6 +112,8 @@ data:
     # Provided if selected user is mTLS:
     ssl.keystore.crt: # certificate for the consuming client signed by the clients' CA
     ssl.keystore.key: # private key for the consuming client
+    ssl.keystore.p12: # certificate and private key as PKCS12 keystore for the consuming client
+    ssl.keystore.password: # keystore password for the PKCS12 keystore for the consuming client
 ```
 
 Developers can make this `Secret` available to their applications themselves, or use an operator that implements the [Service Binding specification](https://servicebinding.io/spec/core/1.0.0/) to do it.

--- a/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaUserData.java
+++ b/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaUserData.java
@@ -83,6 +83,10 @@ public class KafkaUserData {
                     .ifPresent(cert -> secretData.put("ssl.keystore.crt", cert));
             Optional.ofNullable(rawUserData.get("user.key"))
                     .ifPresent(key -> secretData.put("ssl.keystore.key", key));
+            Optional.ofNullable(rawUserData.get("user.p12"))
+                    .ifPresent(key -> secretData.put("ssl.keystore.p12", key));
+            Optional.ofNullable(rawUserData.get("user.password"))
+                    .ifPresent(key -> secretData.put("ssl.keystore.password", key));
         }
         return secretData;
     }

--- a/operator/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/Base64Encoder.java
@@ -14,4 +14,7 @@ public class Base64Encoder {
     public static String encodeUtf8(String data) {
         return ENCODER.encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
+    public static String encode(byte[] data) {
+        return ENCODER.encodeToString(data);
+    }
 }

--- a/operator/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static io.strimzi.kafka.access.Base64Encoder.encodeUtf8;
+import static io.strimzi.kafka.access.Base64Encoder.encode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 
@@ -193,6 +194,8 @@ public class KafkaAccessReconcilerTest {
     void testReconcileWithKafkaUser() {
         final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
         final String key = encodeUtf8("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
+        final String p12 = encode(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        final String password = encodeUtf8("my-super-secret-password");
         final Kafka kafka = ResourceProvider.getKafka(
                 KAFKA_NAME,
                 KAFKA_NAMESPACE,
@@ -214,6 +217,8 @@ public class KafkaAccessReconcilerTest {
         final Map<String, String> kafkaUserSecretData = new HashMap<>();
         kafkaUserSecretData.put("user.crt", cert);
         kafkaUserSecretData.put("user.key", key);
+        kafkaUserSecretData.put("user.p12", p12);
+        kafkaUserSecretData.put("user.password", password);
         kafkaUserSecret.setData(kafkaUserSecretData);
         client.secrets().inNamespace(KAFKA_NAMESPACE).resource(kafkaUserSecret).create();
 
@@ -238,7 +243,9 @@ public class KafkaAccessReconcilerTest {
                         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
                         encodeUtf8(String.format("%s:%s", BOOTSTRAP_HOST, BOOTSTRAP_PORT_9093))
                 ).containsEntry("ssl.keystore.crt", cert)
-                .containsEntry("ssl.keystore.key", key);
+                .containsEntry("ssl.keystore.key", key)
+                .containsEntry("ssl.keystore.p12", p12)
+                .containsEntry("ssl.keystore.password", password);
     }
 
     @Test

--- a/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaUserDataTest.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaUserDataTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.kafka.access.Base64Encoder.encodeUtf8;
+import static io.strimzi.kafka.access.Base64Encoder.encode;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class KafkaUserDataTest {
@@ -111,16 +112,22 @@ public class KafkaUserDataTest {
     void testKafkaUserDataTlsExternalSecret() {
         final String cert = encodeUtf8("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");
         final String key = encodeUtf8("-----BEGIN PRIVATE KEY-----\nMIIEvA\n-----END PRIVATE KEY-----\n");
+        final String p12 = encode(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        final String password = encodeUtf8("my-super-secret-password");
         final KafkaUser kafkaUser = ResourceProvider.getKafkaUserWithStatus(SECRET_NAME, USERNAME, new KafkaUserTlsExternalClientAuthentication());
 
         final Map<String, String> kafkaUserSecretData = new HashMap<>();
         kafkaUserSecretData.put("user.crt", cert);
         kafkaUserSecretData.put("user.key", key);
+        kafkaUserSecretData.put("user.p12", p12);
+        kafkaUserSecretData.put("user.password", password);
         final Secret kafkaUserSecret = new SecretBuilder().withData(kafkaUserSecretData).build();
 
         final Map<String, String> secretData = new KafkaUserData(kafkaUser).withSecret(kafkaUserSecret).getConnectionSecretData();
         assertThat(secretData.get("ssl.keystore.crt")).isEqualTo(cert);
         assertThat(secretData.get("ssl.keystore.key")).isEqualTo(key);
+        assertThat(secretData.get("ssl.keystore.p12")).isEqualTo(p12);
+        assertThat(secretData.get("ssl.keystore.password")).isEqualTo(password);
     }
 
     @Test

--- a/packaging/helm-charts/helm3/strimzi-access-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/README.md
@@ -112,6 +112,8 @@ data:
     # Provided if selected user is mTLS:
     ssl.keystore.crt: # certificate for the consuming client signed by the clients' CA
     ssl.keystore.key: # private key for the consuming client
+    ssl.keystore.p12: # certificate and private key as PKCS12 keystore for the consuming client
+    ssl.keystore.password: # keystore password for the PKCS12 keystore for the consuming client
 ```
 
 Developers can make this `Secret` available to their applications themselves, or use an operator that implements the [Service Binding specification](https://servicebinding.io/spec/core/1.0.0/) to do it.

--- a/systemtest/src/main/java/io/strimzi/kafka/access/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/kafka/access/TestConstants.java
@@ -36,6 +36,8 @@ public interface TestConstants {
     //--------------------------
     String USER_CRT = "user.crt";
     String USER_KEY = "user.key";
+    String USER_P12 = "user.p12";
+    String USER_PASSWORD = "user.password";
     String PASSWORD = "password";
     String SASL_JAAS_CONFIG = "sasl.jaas.config";
 
@@ -50,6 +52,8 @@ public interface TestConstants {
     String SECURITY_PROTOCOL = "securityProtocol";
     String SSL_KEYSTORE_CRT = "ssl.keystore.crt";
     String SSL_KEYSTORE_KEY = "ssl.keystore.key";
+    String SSL_KEYSTORE_P12 = "ssl.keystore.p12";
+    String SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
 
     //--------------------------
     // Duration constants

--- a/systemtest/src/main/java/io/strimzi/kafka/access/templates/SecretTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/kafka/access/templates/SecretTemplates.java
@@ -15,10 +15,12 @@ public class SecretTemplates {
 
     private SecretTemplates() {}
 
-    public static Secret tlsSecretForUser(String namespaceName, String userName, String clusterName, String userKey, String userCrt) {
+    public static Secret tlsSecretForUser(String namespaceName, String userName, String clusterName, String userKey, String userCrt, String userP12, String userPassword) {
         Map<String, String> data = Map.of(
             TestConstants.USER_KEY, userKey,
-            TestConstants.USER_CRT, userCrt
+            TestConstants.USER_CRT, userCrt,
+            TestConstants.USER_P12, userP12,
+            TestConstants.USER_PASSWORD, userPassword
         );
 
         return defaultSecretForUser(namespaceName, userName, clusterName, data);

--- a/systemtest/src/main/java/io/strimzi/kafka/access/utils/Base64Utils.java
+++ b/systemtest/src/main/java/io/strimzi/kafka/access/utils/Base64Utils.java
@@ -25,4 +25,8 @@ public class Base64Utils {
     public static String encodeToBase64(String data) {
         return ENCODER.encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
+
+    public static String encodeToBase64(byte[] data) {
+        return ENCODER.encodeToString(data);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/kafka/access/utils/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/kafka/access/utils/SecretUtils.java
@@ -17,4 +17,12 @@ public class SecretUtils {
         String data = "-----BEGIN CERTIFICATE-----\n" + crt + "\n-----END CERTIFICATE-----\n";
         return Base64Utils.encodeToBase64(data);
     }
+
+    public static String createUserP12(byte[] p12) {
+        return Base64Utils.encodeToBase64(p12);
+    }
+
+    public static String createUserPassword(String password) {
+        return Base64Utils.encodeToBase64(password);
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/kafka/access/KafkaAccessOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/kafka/access/KafkaAccessOperatorST.java
@@ -57,6 +57,8 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         String userKey = SecretUtils.createUserKey("my-super-secret-key");
         String userCrt = SecretUtils.createUserCrt("my-super-secret-crt");
+        String userP12 = SecretUtils.createUserP12(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        String userPassword = SecretUtils.createUserPassword("my-super-secret-password");
 
         List<GenericKafkaListener> listeners = List.of(
             ListenerTemplates.tlsListener(internalListenerName, KafkaListenerType.INTERNAL, new KafkaListenerAuthenticationTls(), internalListenerPort),
@@ -66,7 +68,7 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         Kafka kafka = KafkaTemplates.kafkaWithListeners(namespace, testStorage.getKafkaClusterName(), defaultHost, listeners).build();
         KafkaUser tlsUser = KafkaUserTemplates.kafkaUser(namespace, tlsUserName, new KafkaUserTlsClientAuthentication());
-        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt);
+        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt, userP12, userPassword);
 
         resourceManager.createResourceWithWait(
             kafka,
@@ -178,6 +180,8 @@ public class KafkaAccessOperatorST extends AbstractST {
         
         String userKey = SecretUtils.createUserKey("my-super-secret-key");
         String userCrt = SecretUtils.createUserCrt("my-super-secret-crt");
+        String userP12 = SecretUtils.createUserP12(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        String userPassword = SecretUtils.createUserPassword("my-super-secret-password");
 
         List<GenericKafkaListener> listeners = List.of(
             ListenerTemplates.tlsListener(nodePortListenerName, KafkaListenerType.NODEPORT, new KafkaListenerAuthenticationTls(), nodePortListenerPort),
@@ -186,7 +190,7 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         Kafka kafka = KafkaTemplates.kafkaWithListeners(namespace, testStorage.getKafkaClusterName(), defaultHost, listeners).build();
         KafkaUser tlsUser = KafkaUserTemplates.kafkaUser(namespace, tlsUserName, new KafkaUserTlsClientAuthentication());
-        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt);
+        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt, userP12, userPassword);
 
         resourceManager.createResourceWithWait(
             kafka,
@@ -221,6 +225,8 @@ public class KafkaAccessOperatorST extends AbstractST {
         
         String userKey = SecretUtils.createUserKey("my-super-secret-key");
         String userCrt = SecretUtils.createUserCrt("my-super-secret-crt");
+        String userP12 = SecretUtils.createUserP12(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        String userPassword = SecretUtils.createUserPassword("my-super-secret-password");
 
         List<GenericKafkaListener> listeners = List.of(
             ListenerTemplates.tlsListener(nodePortListenerName, KafkaListenerType.NODEPORT, new KafkaListenerAuthenticationTls(), nodePortListenerPort),
@@ -230,7 +236,7 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         Kafka kafka = KafkaTemplates.kafkaWithListeners(namespace, testStorage.getKafkaClusterName(), defaultHost, listeners).build();
         KafkaUser tlsUser = KafkaUserTemplates.kafkaUser(namespace, tlsUserName, new KafkaUserTlsClientAuthentication());
-        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt);
+        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt, userP12, userPassword);
 
         resourceManager.createResourceWithWait(
             kafka,
@@ -273,6 +279,8 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         String userKey = SecretUtils.createUserKey("my-super-secret-key");
         String userCrt = SecretUtils.createUserCrt("my-super-secret-crt");
+        String userP12 = SecretUtils.createUserP12(new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05});
+        String userPassword = SecretUtils.createUserPassword("my-super-secret-password");
 
         List<GenericKafkaListener> listeners = List.of(
             ListenerTemplates.tlsListener(listenerA, KafkaListenerType.NODEPORT, new KafkaListenerAuthenticationTls(), listenerAPort),
@@ -282,7 +290,7 @@ public class KafkaAccessOperatorST extends AbstractST {
 
         Kafka kafka = KafkaTemplates.kafkaWithListeners(namespace, testStorage.getKafkaClusterName(), defaultHost, listeners).build();
         KafkaUser tlsUser = KafkaUserTemplates.kafkaUser(namespace, tlsUserName, new KafkaUserTlsClientAuthentication());
-        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt);
+        Secret tlsUserSecret = SecretTemplates.tlsSecretForUser(namespace, tlsUserName, testStorage.getKafkaClusterName(), userKey, userCrt, userP12, userPassword);
 
         resourceManager.createResourceWithWait(
             kafka,
@@ -336,6 +344,10 @@ public class KafkaAccessOperatorST extends AbstractST {
                 is(Base64Utils.decodeFromBase64ToString(userData.get(TestConstants.USER_CRT))));
             assertThat(Base64Utils.decodeFromBase64ToString(data.get(TestConstants.SSL_KEYSTORE_KEY)),
                 is(Base64Utils.decodeFromBase64ToString(userData.get(TestConstants.USER_KEY))));
+            assertThat(Base64Utils.decodeFromBase64ToString(data.get(TestConstants.SSL_KEYSTORE_P12)),
+                is(Base64Utils.decodeFromBase64ToString(userData.get(TestConstants.USER_P12))));
+            assertThat(Base64Utils.decodeFromBase64ToString(data.get(TestConstants.SSL_KEYSTORE_PASSWORD)),
+                is(Base64Utils.decodeFromBase64ToString(userData.get(TestConstants.USER_PASSWORD))));
         }
     }
 }


### PR DESCRIPTION
- Copied additional properties from the KafkaUser secret to the KafkaAccess secret
  - `user.p12` mapped to `ssl.keystore.p12`
  - `user.password` mapped to `ssl.keystore.password`
- Updated tests to check the additional fields

Addresses: https://github.com/strimzi/kafka-access-operator/issues/81