### PR TITLE
Add Ready column to KafkaAccess and add KafkaAccess to strimzi category

### DIFF
--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaAccess.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaAccess.java
@@ -4,8 +4,11 @@
  */
 package io.strimzi.kafka.access.model;
 
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumns;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Categories;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.ShortNames;
 import io.fabric8.kubernetes.model.annotation.Version;
@@ -26,6 +29,14 @@ import java.io.Serial;
     builderPackage = Constants.FABRIC8_KUBERNETES_API,
     refs = {@BuildableReference(CustomResource.class), @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class)}
 )
+
+@Categories(value = "strimzi")
+@AdditionalPrinterColumns(value = { 
+    @AdditionalPrinterColumn(jsonPath = ".spec.kafka.listener", name = "Listener"),
+    @AdditionalPrinterColumn(jsonPath = ".spec.kafka.name", name = "Cluster"),
+    @AdditionalPrinterColumn(jsonPath = ".spec.user.name", name = "User"),
+    @AdditionalPrinterColumn(jsonPath = ".status.conditions[?(@.type==\"Ready\")].status", name = "Ready")
+})
 public class KafkaAccess extends CustomResource<KafkaAccessSpec, KafkaAccessStatus> implements Namespaced {
     @Serial
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaReference.java
@@ -18,10 +18,8 @@ import io.sundr.builder.annotations.Buildable;
 public class KafkaReference {
 
     @Required
-    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "Cluster")
     private String name;
     private String namespace;
-    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "Listener")
     private String listener;
 
     /**

--- a/api/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
+++ b/api/src/main/java/io/strimzi/kafka/access/model/KafkaUserReference.java
@@ -22,7 +22,6 @@ public class KafkaUserReference {
     @Required
     private String apiGroup;
     @Required
-    @io.fabric8.crd.generator.annotation.PrinterColumn(name = "User")
     private String name;
     private String namespace;
 

--- a/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/crds/040-Crd-kafkaaccess.yaml
@@ -9,6 +9,8 @@ spec:
   group: access.strimzi.io
   names:
     kind: KafkaAccess
+    categories:
+      - strimzi
     plural: kafkaaccesses
     shortNames:
       - ka
@@ -26,6 +28,10 @@ spec:
           type: string
         - jsonPath: .spec.user.name
           name: User
+          priority: 0
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
           priority: 0
           type: string
       name: v1alpha1

--- a/packaging/install/040-Crd-kafkaaccess.yaml
+++ b/packaging/install/040-Crd-kafkaaccess.yaml
@@ -9,6 +9,8 @@ spec:
   group: access.strimzi.io
   names:
     kind: KafkaAccess
+    categories:
+      - strimzi
     plural: kafkaaccesses
     shortNames:
       - ka
@@ -26,6 +28,10 @@ spec:
           type: string
         - jsonPath: .spec.user.name
           name: User
+          priority: 0
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
           priority: 0
           type: string
       name: v1alpha1


### PR DESCRIPTION
This PR adds a "Ready" column as an additional printer column on the KafkaAccess CRD, for example: 

```
$ kubectl get kafkaaccess -n myproject
NAME              LISTENER   CLUSTER      USER      READY
my-kafka-access   tls        my-cluster   my-user   False
```

and also adds KafkaAccess to the "strimzi" category
```
$ kubectl get strimzi -n myproject
NAME                                            LISTENER   CLUSTER      USER      READY
kafkaaccess.access.strimzi.io/my-kafka-access   tls        my-cluster   my-user   False

NAME                                                  PODS   READY PODS   CURRENT PODS   AGE
strimzipodset.core.strimzi.io/my-cluster-broker       3      3            3              7h10m
strimzipodset.core.strimzi.io/my-cluster-controller   3      3            3              7h10m

NAME                                        DESIRED REPLICAS   ROLES            NODEIDS
kafkanodepool.kafka.strimzi.io/broker       3                  ["broker"]       [0,1,2]
kafkanodepool.kafka.strimzi.io/controller   3                  ["controller"]   [3,4,5]

NAME                                READY   METADATA STATE   WARNINGS
kafka.kafka.strimzi.io/my-cluster   True    KRaft            

```
Closes #53 