### PR TITLE
Add project names to modules + add sources plugin for deploying artifacts to Maven Central

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,7 +9,7 @@
         <artifactId>kafka-access-operator</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
-
+    <name>Kafka Access Operator - API</name>
     <artifactId>api</artifactId>
 
     <properties>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>kafka-access-operator</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
-
+    <name>Kafka Access Operator</name>
     <artifactId>operator</artifactId>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <spotbugs.version>4.5.3</spotbugs.version>
         <spotbugs-maven-plugin.version>4.5.3.0</spotbugs-maven-plugin.version>
         <maven.javadoc.version>3.5.0</maven.javadoc.version>
+        <maven.source.version>3.3.1</maven.source.version>
         <maven.shade.version>3.1.0</maven.shade.version>
         <maven.dependency.version>3.3.0</maven.dependency.version>
         <maven.assembly.version>3.3.0</maven.assembly.version>
@@ -338,6 +339,19 @@
                     <!-- Configures the file for excluding warnings -->
                     <excludeFilterFile>${project.basedir}/../.spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -9,6 +9,7 @@
         <version>0.2.0-SNAPSHOT</version>
     </parent>
 
+    <name>Kafka Access Operator - System tests</name>
     <artifactId>systemtest</artifactId>
 
     <properties>


### PR DESCRIPTION
This PR adds missing project names to modules that are missing it + adds sources plugin for correctly deploying artifacts to the Maven Central.