### PR TITLE
Set proper permissions for codeql action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,9 +20,10 @@ on:
   schedule:
     - cron: '23 17 * * 3'
 
-# Declare default permissions as read only
+# Declare default permissions
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   analyze:


### PR DESCRIPTION
Codeql action has to have `security-events: write` permissions when executed in default branch - https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions 