### PR TITLE
add helm chart values for pod annotations and labels

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-access-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/README.md
@@ -55,6 +55,8 @@ The following table lists the available configurable parameters of the Strimzi c
 | `livenessProbe.periodSeconds`        | Liveness probe period (in seconds)                         | `30`      |
 | `readinessProbe.initialDelaySeconds` | Readiness probe initial delay (in seconds)                 | `10`      |
 | `readinessProbe.periodSeconds`       | Readiness probe period (in seconds)                        | `30`      |
+| `annotations`                        | Additional annotations to apply to Access Operator Pod     | `{}`      |
+| `labels`                             | Additional labels to apply to Access Operator Pod          | `{}`      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-access-operator/templates/050-Deployment.yaml
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/templates/050-Deployment.yaml
@@ -19,6 +19,13 @@ spec:
       labels:
         app: strimzi-access-operator
         strimzi.io/kind: access-operator
+        {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 10 }}
+        {{- end }}
+      {{- if .Values.annotations }}
+      annotations:
+        {{- toYaml .Values.annotations | nindent 10 }}
+      {{- end }}
     spec:
       serviceAccountName: strimzi-access-operator
       {{- if .Values.image.imagePullSecrets }}

--- a/packaging/helm-charts/helm3/strimzi-access-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-access-operator/values.yaml
@@ -21,3 +21,5 @@ livenessProbe:
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 30
+annotations: {}
+labels: {}


### PR DESCRIPTION
This pull request adds additional options to the helm chart for customization of the operator deployment. 

One example of where this is necessary is hosting the Strimzi Access Operator in an Azure Kubernetes Cluster with a layer 7 egress firewall to set the `kubernetes.azure.com/set-kube-service-host-fqdn` annotation. More info: https://learn.microsoft.com/en-us/azure/aks/outbound-rules-control-egress#required-outbound-network-rules-and-fqdns-for-aks-clusters