### PR TITLE
Bump dependencies - JOSDK, tests related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 
         <!-- Runtime dependencies -->
-        <javaoperatorsdk.version>5.1.2</javaoperatorsdk.version>
+        <javaoperatorsdk.version>5.3.3</javaoperatorsdk.version>
         <fabric8.version>7.2.0</fabric8.version>
         <sundrio.version>0.200.0</sundrio.version>
         <strimzi.version>0.48.0</strimzi.version>
@@ -80,8 +80,8 @@
         <slf4j.version>1.7.36</slf4j.version>
         <!-- Used for test-frame and the systemtests-->
         <slf4j2.version>2.0.16</slf4j2.version>
-        <log4j.version>2.24.1</log4j.version>
-        <jetty.version>11.0.24</jetty.version>
+        <log4j.version>2.25.4</log4j.version>
+        <jetty.version>11.0.26</jetty.version>
         <jetty.jakarta-servlet-api.version>5.0.2</jetty.jakarta-servlet-api.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
This PR bumps several dependencies - mainly Java Operator SDK and some of the tests related dependencies - before next release.