### PR TITLE
Fix `NoSuchMethodError` on slf4j after update of JoSDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,9 @@
         <strimzi.version>1.0.0</strimzi.version>
         <kafka.clients.version>4.2.0</kafka.clients.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
+        <slf4j.version>2.0.16</slf4j.version>
 
-        <!-- Used for the operator because of the Java OperatorSDK -->
-        <slf4j.version>1.7.36</slf4j.version>
         <!-- Used for test-frame and the systemtests-->
-        <slf4j2.version>2.0.16</slf4j2.version>
         <log4j.version>2.25.4</log4j.version>
         <jetty.version>11.0.26</jetty.version>
         <jetty.jakarta-servlet-api.version>5.0.2</jetty.jakarta-servlet-api.version>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j2.version}</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
In the last PR bumping JoSDK I didn't bump the slf4j version to be 2.x - and based on the tests in the release branch it was missing a method:
```
Error: Exception in thread "pool-180-thread-2" java.lang.NoSuchMethodError: 'org.slf4j.spi.LoggingEventBuilder org.slf4j.Logger.atLevel(org.slf4j.event.Level)'
	at io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor.channelRead(ServerBootstrap.java:241)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleErrorStatusHandler(ReconciliationDispatcher.java:247)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleReconcile(ReconciliationDispatcher.java:147)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleDispatch(ReconciliationDispatcher.java:110)
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleExecution(ReconciliationDispatcher.java:75)
	at io.javaoperatorsdk.operator.processing.event.EventProcessor$ReconcilerExecutor.run(EventProcessor.java:535)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
Bumping the version to 2.0.16 solved this issue.
Weird is that it didn't fail in the tests of the PR - we should investigate that.