### PR TITLE
Use slf4j-impl after movement to slf4j 2.x

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <!-- Test dependencies -->
         <dependency>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/operator/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/KafkaAccessReconcilerTest.java
@@ -67,7 +67,7 @@ public class KafkaAccessReconcilerTest {
     private static final String NEW_USER_PROVIDED_SECRET_NAME = "my-new-kafka-access-secret";
     private static final int BOOTSTRAP_PORT_9092 = 9092;
     private static final int BOOTSTRAP_PORT_9093 = 9093;
-    private static final long TEST_TIMEOUT = 1000;
+    private static final long TEST_TIMEOUT = 3000;
 
     KubernetesClient client;
     Operator operator;

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
@@ -391,7 +391,7 @@
                                 <ignoredDependency>io.fabric8:crd-generator-api-v2:jar:${fabric8.version}</ignoredDependency>
                                 <ignoredDependency>io.fabric8:generator-annotations:jar:${fabric8.version}</ignoredDependency>
                                 <ignoredDependency>io.fabric8:kubernetes-httpclient-jdk:jar:${fabric8.version}</ignoredDependency>
-                                <ignoredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredDependency>
+                                <ignoredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredDependency>
                                 <ignoredDependency>io.sundr:builder-annotations:jar:${sundrio.version}</ignoredDependency>
                             </ignoredDependencies>
                         </configuration>


### PR DESCRIPTION
After movement to slf4j 2.x version, I forgot to change the impl dependency to also use the slf4j2.
This caused:

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/opt/strimzi/libs/org.apache.logging.log4j.log4j-slf4j-impl-2.25.4.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

This PR fixes this by using the `log4j-slf4j2-impl`.