### PR TITLE
Fix re-reconciliation on KafkaAccess' Secret creation

### DIFF
--- a/operator/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
+++ b/operator/src/main/java/io/strimzi/kafka/access/KafkaAccessReconciler.java
@@ -254,6 +254,7 @@ public class KafkaAccessReconciler implements Reconciler<KafkaAccess> {
                 InformerEventSourceConfiguration.from(Secret.class, KafkaAccess.class)
                         .withLabelSelector(String.format("%s=%s", KafkaAccessMapper.MANAGED_BY_LABEL_KEY, KafkaAccessMapper.KAFKA_ACCESS_LABEL_VALUE))
                         .withSecondaryToPrimaryMapper(secret -> KafkaAccessMapper.secretSecondaryToPrimaryMapper(context.getPrimaryCache().list(), secret))
+                        .withOnAddFilter(secret -> false)
                         .build(),
                 context);
         LOGGER.info("Finished preparing event sources");


### PR DESCRIPTION
While debugging the #138 and fixing the test, I found out that there is another "reconciliation" once we create the KafkaAccess' Secret.
So once the Secret with the label appears, it will trigger an event for reconciliation, because the Secret was added.

That caused the race condition - when the reconciler creates the operator-managed Secret, the `kafkaAccessSecretEventSource` informer picks up the ADD event and triggers a false second reconciliation, whose `patchStatus() `call can race with concurrent spec updates. Because the operator is the only actor creating secrets with the `kafka-access-operator` `managed-by` label, we can suppress the ADD events using the `withOnAddFilter(secret -> false)` - the informer cache remains unaffected.

The tests are now passing - tried 50 times without any failure. Hopefully it will go without issues through CI as well :)

Fixes #138 