### PR TITLE
Bundle all cluster CAs in ssl.truststore.crt

### DIFF
--- a/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
+++ b/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
@@ -147,27 +147,23 @@ public class KafkaListener {
     // Bundle both current and previous Cluster CAs so clients survive CA key replacement.
     private static String buildCaBundle(final Map<String, String> secretData) {
         final Base64.Decoder decoder = Base64.getDecoder();
-        final List<String> anchors = secretData.entrySet().stream()
+        final List<String> leaves = secretData.entrySet().stream()
                 .filter(entry -> entry.getKey().endsWith(".crt"))
                 .sorted(Map.Entry.comparingByKey())
                 .map(entry -> new String(decoder.decode(entry.getValue()), StandardCharsets.UTF_8))
-                .map(KafkaListener::lastCertificate)
+                .map(KafkaListener::firstCertificate)
                 .flatMap(Optional::stream)
                 .toList();
-        if (anchors.isEmpty()) {
+        if (leaves.isEmpty()) {
             return null;
         }
-        final String bundle = anchors.stream().collect(Collectors.joining("\n", "", "\n"));
+        final String bundle = leaves.stream().collect(Collectors.joining("\n", "", "\n"));
         return Base64.getEncoder().encodeToString(bundle.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static Optional<String> lastCertificate(final String pem) {
+    private static Optional<String> firstCertificate(final String pem) {
         final Matcher matcher = PEM_CERTIFICATE.matcher(pem);
-        String last = null;
-        while (matcher.find()) {
-            last = matcher.group();
-        }
-        return Optional.ofNullable(last);
+        return matcher.find() ? Optional.of(matcher.group()) : Optional.empty();
     }
 
     private SecurityProtocol getSecurityProtocol() {

--- a/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
+++ b/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
@@ -29,6 +29,9 @@ import static io.strimzi.kafka.access.internal.KafkaParser.LISTENER_AUTH_NONE;
  */
 public class KafkaListener {
 
+    private static final Pattern PEM_CERTIFICATE = Pattern.compile(
+            "-----BEGIN CERTIFICATE-----[\\s\\S]*?-----END CERTIFICATE-----");
+
     private final String name;
     private final KafkaListenerType type;
     private final boolean tls;
@@ -140,9 +143,6 @@ public class KafkaListener {
         }
         return data;
     }
-
-    private static final Pattern PEM_CERTIFICATE = Pattern.compile(
-            "-----BEGIN CERTIFICATE-----[\\s\\S]*?-----END CERTIFICATE-----");
 
     // Bundle both current and previous Cluster CAs so clients survive CA key replacement.
     private static String buildCaBundle(final Map<String, String> secretData) {

--- a/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
+++ b/operator/src/main/java/io/strimzi/kafka/access/internal/KafkaListener.java
@@ -15,8 +15,12 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static io.strimzi.kafka.access.internal.KafkaParser.LISTENER_AUTH_NONE;
 
@@ -131,10 +135,39 @@ public class KafkaListener {
         data.put("bootstrap-servers", bootstrapServers);
         if (this.tls) {
             Optional.ofNullable(this.caCertSecret)
-                    .map(secretData -> secretData.get("ca.crt"))
-                    .ifPresent(cert -> data.put("ssl.truststore.crt", cert));
+                    .map(KafkaListener::buildCaBundle)
+                    .ifPresent(bundle -> data.put("ssl.truststore.crt", bundle));
         }
         return data;
+    }
+
+    private static final Pattern PEM_CERTIFICATE = Pattern.compile(
+            "-----BEGIN CERTIFICATE-----[\\s\\S]*?-----END CERTIFICATE-----");
+
+    // Bundle both current and previous Cluster CAs so clients survive CA key replacement.
+    private static String buildCaBundle(final Map<String, String> secretData) {
+        final Base64.Decoder decoder = Base64.getDecoder();
+        final List<String> anchors = secretData.entrySet().stream()
+                .filter(entry -> entry.getKey().endsWith(".crt"))
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new String(decoder.decode(entry.getValue()), StandardCharsets.UTF_8))
+                .map(KafkaListener::lastCertificate)
+                .flatMap(Optional::stream)
+                .toList();
+        if (anchors.isEmpty()) {
+            return null;
+        }
+        final String bundle = anchors.stream().collect(Collectors.joining("\n", "", "\n"));
+        return Base64.getEncoder().encodeToString(bundle.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Optional<String> lastCertificate(final String pem) {
+        final Matcher matcher = PEM_CERTIFICATE.matcher(pem);
+        String last = null;
+        while (matcher.find()) {
+            last = matcher.group();
+        }
+        return Optional.ofNullable(last);
     }
 
     private SecurityProtocol getSecurityProtocol() {

--- a/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
@@ -115,8 +115,8 @@ public class KafkaListenerTest {
     }
 
     @Test
-    @DisplayName("When a .crt entry contains a certificate chain, then only the last certificate (root) is included in the trust bundle")
-    void testTLSKafkaListenerCollapsesChainToTrustAnchor() {
+    @DisplayName("When a .crt entry contains a certificate chain, then only the leaf CA cert (first in the file) is included in the trust bundle")
+    void testTLSKafkaListenerCollapsesChainToLeafCert() {
         final String chain = "-----BEGIN CERTIFICATE-----\nLEAFCERT\n-----END CERTIFICATE-----\n"
                 + "-----BEGIN CERTIFICATE-----\nINTERMED\n-----END CERTIFICATE-----\n"
                 + "-----BEGIN CERTIFICATE-----\nROOTCERT\n-----END CERTIFICATE-----\n";
@@ -128,7 +128,7 @@ public class KafkaListenerTest {
 
         final Map<String, String> secretData = listener.getConnectionSecretData();
 
-        final String expectedBundle = encodeToString("-----BEGIN CERTIFICATE-----\nROOTCERT\n-----END CERTIFICATE-----\n");
+        final String expectedBundle = encodeToString("-----BEGIN CERTIFICATE-----\nLEAFCERT\n-----END CERTIFICATE-----\n");
         assertThat(secretData).containsEntry("ssl.truststore.crt", expectedBundle);
     }
 

--- a/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
+++ b/operator/src/test/java/io/strimzi/kafka/access/internal/KafkaListenerTest.java
@@ -93,6 +93,61 @@ public class KafkaListenerTest {
     }
 
     @Test
+    @DisplayName("When the Cluster CA Secret contains multiple .crt entries, then ssl.truststore.crt bundles them all")
+    void testTLSKafkaListenerBundlesAllClusterCas() {
+        final String certA = "-----BEGIN CERTIFICATE-----\nMIIFAAAAAA\n-----END CERTIFICATE-----\n";
+        final String certB = "-----BEGIN CERTIFICATE-----\nMIIFBBBBBB\n-----END CERTIFICATE-----\n";
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", encodeToString(certA));
+        certSecretData.put("ca-2026-01-01T00-00-00Z.crt", encodeToString(certB));
+        certSecretData.put("ca.p12", encodeToString("ignored-binary"));
+        certSecretData.put("ca.password", encodeToString("ignored-password"));
+        final GenericKafkaListener genericKafkaListener = ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true);
+        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092)
+                .withCaCertSecret(certSecretData);
+
+        final Map<String, String> secretData = listener.getConnectionSecretData();
+
+        // Sorted key order: ca-<date>.crt precedes ca.crt.
+        final String expectedBundle = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFBBBBBB\n-----END CERTIFICATE-----\n"
+                + "-----BEGIN CERTIFICATE-----\nMIIFAAAAAA\n-----END CERTIFICATE-----\n");
+        assertThat(secretData).containsEntry("ssl.truststore.crt", expectedBundle);
+    }
+
+    @Test
+    @DisplayName("When a .crt entry contains a certificate chain, then only the last certificate (root) is included in the trust bundle")
+    void testTLSKafkaListenerCollapsesChainToTrustAnchor() {
+        final String chain = "-----BEGIN CERTIFICATE-----\nLEAFCERT\n-----END CERTIFICATE-----\n"
+                + "-----BEGIN CERTIFICATE-----\nINTERMED\n-----END CERTIFICATE-----\n"
+                + "-----BEGIN CERTIFICATE-----\nROOTCERT\n-----END CERTIFICATE-----\n";
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.crt", encodeToString(chain));
+        final GenericKafkaListener genericKafkaListener = ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true);
+        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092)
+                .withCaCertSecret(certSecretData);
+
+        final Map<String, String> secretData = listener.getConnectionSecretData();
+
+        final String expectedBundle = encodeToString("-----BEGIN CERTIFICATE-----\nROOTCERT\n-----END CERTIFICATE-----\n");
+        assertThat(secretData).containsEntry("ssl.truststore.crt", expectedBundle);
+    }
+
+    @Test
+    @DisplayName("When the Cluster CA Secret contains no .crt entry, then ssl.truststore.crt is not set")
+    void testTLSKafkaListenerNoCertEntry() {
+        final Map<String, String> certSecretData = new HashMap<>();
+        certSecretData.put("ca.p12", encodeToString("ignored-binary"));
+        certSecretData.put("ca.password", encodeToString("ignored-password"));
+        final GenericKafkaListener genericKafkaListener = ResourceProvider.getListener(LISTENER_1, KafkaListenerType.INTERNAL, true);
+        final KafkaListener listener = new KafkaListener(genericKafkaListener).withBootstrapServer(BOOTSTRAP_SERVER_9092)
+                .withCaCertSecret(certSecretData);
+
+        final Map<String, String> secretData = listener.getConnectionSecretData();
+
+        assertThat(secretData).doesNotContainKey("ssl.truststore.crt");
+    }
+
+    @Test
     @DisplayName("When a Kafka listener with SASL auth and TLS enabled is created, then the connection data is correct and has security protocol SASL_SSL")
     void testKafkaListenerWithSaslAuthAndTls() {
         final String cert = encodeToString("-----BEGIN CERTIFICATE-----\nMIIFLTCCAx\n-----END CERTIFICATE-----\n");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Resolves #124.

`KafkaListener.getConnectionSecretData` copies only `ca.crt` into `ssl.truststore.crt`. During a Cluster CA key replacement the Secret holds both the current and previous CA (`ca-<notAfter>.crt`), so clients trust only one and can't follow the rotation.

Bundle every `.crt` entry from the Cluster CA Secret into `ssl.truststore.crt`, sorted by key for a deterministic bundle. If an entry is a chain, only the leaf CA cert (first block in the file) is included. Non-`.crt` entries (`ca.p12`, `ca.password`) are ignored.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [x] Reference relevant issue(s) and close them after merging
- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))